### PR TITLE
Added connect-livereload snippet

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ grunt server:dist
 
 ### Livereload
 
-`grunt server` will watch client files in `app/`, and server files inside `lib/`, restarting the Express server when a change is detected. This requires the [Livereload plugin](https://chrome.google.com/webstore/detail/livereload/jnihajbhpnppcggbcgedagnkighmdlei) or equivalant to refresh your browser. Be sure that the plugin is enabled on the page you're testing.
+`grunt server` will watch client files in `app/`, and server files inside `lib/`, restarting the Express server when a change is detected.
 
 ### Deployment
 

--- a/templates/common/_package.json
+++ b/templates/common/_package.json
@@ -30,7 +30,8 @@
     "load-grunt-tasks": "~0.2.0",
     "time-grunt": "~0.2.1",
     "grunt-express-server": "~0.4.5",
-    "grunt-open": "~0.2.0"
+    "grunt-open": "~0.2.0",
+    "connect-livereload": "~0.3.0"
   },
   "engines": {
     "node": ">=0.8.0"

--- a/templates/express/server.js
+++ b/templates/express/server.js
@@ -31,6 +31,7 @@ app.configure(function(){
 });
 
 app.configure('development', function(){
+  app.use(require('connect-livereload')());
   app.use(express.static(path.join(__dirname, '.tmp')));
   app.use(express.static(path.join(__dirname, 'app')));
   app.use(express.errorHandler());


### PR DESCRIPTION
This removes the need for installing LiveReload as a plug-in.

You could optionally pass in — and check for — a `LIVERELOAD_PORT` env in much the same way as `PORT`.
