### PR TITLE
Separate client and server watchers

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -51,12 +51,19 @@ module.exports = function (grunt) {
         files: ['<%%= yeoman.app %>/styles/{,*/}*.{scss,sass}'],
         tasks: ['compass:server', 'autoprefixer']
       },<% } %>
+      livereload: {
+        files: [
+          '<%= yeoman.app %>/{,*//*}*.html',
+          '{.tmp,<%= yeoman.app %>}/styles/{,*//*}*.css',
+          '{.tmp,<%= yeoman.app %>}/scripts/{,*//*}*.js',
+          '<%= yeoman.app %>/images/{,*//*}*.{png,jpg,jpeg,gif,webp,svg}',
+        ],
+        options: {
+          livereload: true
+        }
+      },
       express: {
           files: [
-              '<%%= yeoman.app %>/{,*//*}*.html',
-              '{.tmp,<%%= yeoman.app %>}/styles/{,*//*}*.css',
-              '{.tmp,<%%= yeoman.app %>}/scripts/{,*//*}*.js',
-              '<%%= yeoman.app %>/images/{,*//*}*.{png,jpg,jpeg,gif,webp,svg}',
               'server.js',
               'lib/{,*//*}*.{js,json}'
           ],


### PR DESCRIPTION
This separates the watch into two; client and server. Client-side changes don't require a node restart, so they only trigger a LiveReload.

The `livereload: true` in the `express` target is optional. You could decide that server-side changes don't require a reload, but there is a use case for leaving it in too, so I've left it.
