### PR TITLE
docs(readme): Adding optional deployment instructions for MongoDB

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,8 @@ While deployment should be easy enough with the `grunt dist` build, we provide a
 
 4. `cd heroku && git push heroku master`
 
+5. Optional (if using mongoDB) `heroku addons:add mongohq`
+
 That's it! Your app should be live and shareable. Type `heroku open` to view it.  
 
 ## Generators


### PR DESCRIPTION
Adding optional instruction for MongoDB to help people get up and
running faster. Without this the app does not function properly.
