### PR TITLE
feat(app): Enable Node debug mode

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -31,7 +31,8 @@ module.exports = function (grunt) {
       },
       dev: {
         options: {
-          script: 'server.js'
+          script: 'server.js',
+          debug: true
         }
       },
       prod: {


### PR DESCRIPTION
To resolve [#27](https://github.com/DaftMonk/generator-angular-fullstack/issues/27)

Run up the app, as usual with `grunt serve`. This will start Node in debug mode with `--debug`, on default port `5858`. You can then connect to the running process for debugging with [node-inspector](https://github.com/node-inspector/node-inspector) or WebStorm (or anything I guess). In WebStorm, use remote debugging to:

![screen shot 2013-12-05 at 12 04 40 pm](https://f.cloud.github.com/assets/577141/1678457/8160d6d6-5d38-11e3-9750-2327cc02ca2b.png)

Optionally, this config could be re-written to require something like `grunt serve:debug`, but I figure in dev mode, you probably want debug on anyway?
