### PR TITLE
Fixed bug in chrome, which caused bootsrap buttons to have a of height of 33px instead of 34px

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -199,7 +199,8 @@ module.exports = function (grunt) {
         httpGeneratedImagesPath: '/images/generated',
         httpFontsPath: '/styles/fonts',
         relativeAssets: false,
-        assetCacheBuster: false
+        assetCacheBuster: false,
+        raw: "Sass::Script::Number.precision = 10\n"
       },
       dist: {
         options: {


### PR DESCRIPTION
Hi there,

I had a strange bug today in my chome browser which caused bootrap buttons to be 33px heigh instead of the usual 34px. After some research, I found out that its a know issue and can be fixed by increasing the the precision of the sass compiler.

Cheers,
Peer

Found cause and fix here: 
https://github.com/thomas-mcdonald/bootstrap-sass/issues/409
https://github.com/gruntjs/grunt-contrib-compass/issues/113
