### PR TITLE
Fixed bug in chrome, which caused buttons to have a of height of 33px in...

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -199,7 +199,8 @@ module.exports = function (grunt) {
         httpGeneratedImagesPath: '/images/generated',
         httpFontsPath: '/styles/fonts',
         relativeAssets: false,
-        assetCacheBuster: false
+        assetCacheBuster: false,
+        raw: "Sass::Script::Number.precision = 10\n"
       },
       dist: {
         options: {


### PR DESCRIPTION
...stead of 34px

Found cause and fix here: https://github.com/thomas-mcdonald/bootstrap-sass/issues/409
