### PR TITLE
stop trying to require non-js/hidden files

### DIFF
--- a/templates/express/server.js
+++ b/templates/express/server.js
@@ -21,6 +21,7 @@ var db = mongoose.connect(config.mongo.uri, config.mongo.options);
 // Bootstrap models
 var modelsPath = path.join(__dirname, 'lib/models');
 fs.readdirSync(modelsPath).forEach(function (file) {
+  if (!file.match(/\.js$/)) return; // only .js files
   require(modelsPath + '/' + file);
 });
 


### PR DESCRIPTION
editors like VIM place hidden files for recovery/etc in certain cases. This changes the logic for model loading to only require `.js` files, to avoid that case.

also thought about only requiring non-hidden files (`!match(/^\./)`), but thought this was more correct.
