### PR TITLE
fix(grunt): include partial sub-directories in htmlmin

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -300,7 +300,7 @@ module.exports = function (grunt) {
         files: [{
           expand: true,
           cwd: '<%%= yeoman.app %>/views',
-          src: ['*.html', 'partials/*.html'],
+          src: ['*.html', 'partials/**/*.html'],
           dest: '<%%= yeoman.dist %>/views'
         }]
       }


### PR DESCRIPTION
With this change, partial sub-directories are now processed with htmlmin and copied over to dist on grunt build.
