### PR TITLE
fix(node:express): return 404 status code when partial can't be found

### DIFF
--- a/templates/express/controllers/index.js
+++ b/templates/express/controllers/index.js
@@ -10,6 +10,8 @@ exports.partials = function(req, res) {
   var requestedView = path.join('./', stripped);
   res.render(requestedView, function(err, html) {
     if(err) {
+      console.log("Error rendering partial '" + requestedView + "'\n", err);
+      res.status(404);
       res.send(404);
     } else {
       res.send(html);


### PR DESCRIPTION
Previously, a 200 status code would be sent when a partial couldn't be rendered.
