### PR TITLE
fix(server): fix configuration so that (express) errorHandler works

### DIFF
--- a/templates/express/config/express.js
+++ b/templates/express/config/express.js
@@ -61,10 +61,10 @@ module.exports = function(app) {
     <% } %>
     // Router (only error handlers should come after this)
     app.use(app.router);
-    
-    // Error handler
-    if('development' === app.get('env')) {
-      app.use(express.errorHandler())
-    }
+  });
+
+  // Error handler
+  app.configure('development', function(){
+    app.use(express.errorHandler());
   });
 };


### PR DESCRIPTION
The error handler needs to be below app.use(app.router), otherwise it's never used.
