### PR TITLE
disables the caching functionality of imagemin transitionally

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -309,6 +309,9 @@ module.exports = function (grunt) {
 
     // The following *-min tasks produce minified files in the dist folder
     imagemin: {
+      options : {
+        cache: false
+      },
       dist: {
         files: [{
           expand: true,


### PR DESCRIPTION
disables the caching functionality of imagemin transitionally until the problem with the current version of grunt-contrib-imagemin (0.5.0) is sorted out.

see #123
