### PR TITLE
Enable express response compression

### DIFF
--- a/templates/express/config/express.js
+++ b/templates/express/config/express.js
@@ -29,6 +29,7 @@ module.exports = function(app) {
   });
 
   app.configure('production', function(){
+    app.use(express.compress());
     app.use(express.favicon(path.join(config.root, 'public', 'favicon.ico')));
     app.use(express.static(path.join(config.root, 'public')));
     app.set('views', config.root + '/views');


### PR DESCRIPTION
Since express 3, compression can be enabled as simple as adding one line of code:
app.use(express.compress());
