### PR TITLE
Update Gruntfile.js: mochaTest through watch should run in 'test' env

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -67,7 +67,7 @@ module.exports = function (grunt) {
       },
       mochaTest: {
         files: ['test/server/{,*/}*.js'],
-        tasks: ['mochaTest']
+        tasks: ['env:test', 'mochaTest']
       },
       jsTest: {
         files: ['test/client/spec/{,*/}*.js'],


### PR DESCRIPTION
mochaTest task needs to be run in 'test' environment. To avoid DB flushing when mochaTest is called by watch, first call 'env:test' task before 'mochaTest'
