### PR TITLE
Lower case user email field

### DIFF
--- a/templates/express/config/passport.js
+++ b/templates/express/config/passport.js
@@ -26,7 +26,7 @@ passport.use(new LocalStrategy({
   },
   function(email, password, done) {
     User.findOne({
-      email: email
+      email: email.toLowerCase()
     }, function(err, user) {
       if (err) return done(err);
       

--- a/templates/express/models/user.js
+++ b/templates/express/models/user.js
@@ -11,7 +11,7 @@ var authTypes = ['github', 'twitter', 'facebook', 'google'];
  */
 var UserSchema = new Schema({
   name: String,
-  email: String,
+  email: { type: String, lowercase: true },
   role: {
     type: String,
     default: 'user'


### PR DESCRIPTION
Lower case the user email field when passport queries to find a user
during login. Also lowercase the email on user creations. Fix #177
