### PR TITLE
404.html file not being served

### DIFF
--- a/templates/express/controllers/index.js
+++ b/templates/express/controllers/index.js
@@ -2,17 +2,12 @@
 
 var path = require('path');
 
-/**
- * Send partial, or 404 if it doesn't exist
- */
-exports.partials = function(req, res) {
+var tryPath = function(req, res, onPathNotFound) {
   var stripped = req.url.split('.')[0];
   var requestedView = path.join('./', stripped);
   res.render(requestedView, function(err, html) {
     if(err) {
-      console.log("Error rendering partial '" + requestedView + "'\n", err);
-      res.status(404);
-      res.send(404);
+      onPathNotFound(err, requestedView);
     } else {
       res.send(html);
     }
@@ -20,8 +15,27 @@ exports.partials = function(req, res) {
 };
 
 /**
- * Send our single page app
+ * Send partial, or 404 if it doesn't exist
+ */
+exports.partials = function(req, res) {
+  tryPath(req, res, function(err, requestedView) {
+    console.log("Error rendering partial '" + requestedView + "'\n", err);
+    res.status(404);
+    res.send(404);
+  });
+};
+
+/**
+ * Try and send the HTML page
+ * If it doesn't exist, send the index page
+ * This allows single page app in HTML5 history mode
  */
 exports.index = function(req, res) {
-  res.render('index');
+  tryPath(req, res, function() {
+    // The HTML file isn't on the server.
+    // This is probably a HTML5 route in the Angular app,
+    // so send the index file and let Angular take over.
+    console.log('index taking over');
+    res.render('index');
+  });
 };

--- a/templates/express/routes.js
+++ b/templates/express/routes.js
@@ -33,9 +33,11 @@ module.exports = function(app) {
       res.send(404);
     });
 
-  // All other routes to use Angular routing in app/scripts/app.js
+  // Partials get their own route
   app.route('/partials/*')
     .get(index.partials);
+
+  // For everything else
   app.route('/*')
     .get(<% if(mongoPassportUser) { %> middleware.setUserCookie,<% } %> index.index);
 };


### PR DESCRIPTION
Currently the `404.html` file in the `app/views` folder can't be served as express is sending `index.html` for any request that isn't an API call or a partial.

This PR uses the same methodology as for the partials - i.e. first express tries to render a file by the passed name, otherwise falling back to `index.html`. This way, custom error pages and any other static / server-side pages can be added to the `app/views` folder and served as normal.