### PR TITLE
Fix async errors in user model tests.

### DIFF
--- a/templates/express/test/user/model.js
+++ b/templates/express/test/user/model.js
@@ -16,13 +16,15 @@ describe('User Model', function() {
     });
 
     // Clear users before testing
-    User.remove().exec();
-    done();
+    User.remove().exec().then(function() {
+      done();
+    });
   });
 
   afterEach(function(done) {
-    User.remove().exec();
-    done();
+    User.remove().exec().then(function() {
+      done();
+    });
   });
 
   it('should begin with no users', function(done) {


### PR DESCRIPTION
Occasionally things will happen "out of order" unless we explicitly wait for them.

This fixes #182 and a couple of other possible async problems I noticed.
