### PR TITLE
Revert "disables the caching functionality of imagemin transitionally un...

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -306,9 +306,6 @@ module.exports = function (grunt) {
 
     // The following *-min tasks produce minified files in the dist folder
     imagemin: {
-      options : {
-        cache: false
-      },
       dist: {
         files: [{
           expand: true,


### PR DESCRIPTION
...til the problem with the current version of grunt-contrib-imagemin (0.5.0) is sorted out"

This reverts commit 3e435fa74b1574223f129867621a9a800cea2af9.

The problem doesn't seem to occur any longer.

I guess some newer grunt deps fixed it ... would like to now what change fixed it - as the dependency is still on grunt-contrib-imagemin (0.5.0) 
