### PR TITLE
added private to package.json

### DIFF
--- a/templates/common/_package.json
+++ b/templates/common/_package.json
@@ -70,5 +70,6 @@
   },
   "engines": {
     "node": ">=0.10.0"
-  }
+  },
+  "private": true
 }


### PR DESCRIPTION
This removes these warnings from NPM:

npm WARN package.json myApp@0.0.0 No description
npm WARN package.json myApp@0.0.0 No repository field.
npm WARN package.json myApp@0.0.0 No README data

It also stops users from accidentally publishing to NPM.
