### PR TITLE
refactor(templates:express:config): use cached version of env

### DIFF
--- a/templates/express/config/express.js
+++ b/templates/express/config/express.js
@@ -69,7 +69,7 @@ module.exports = function(app) {
   app.use(passport.session());<% } %>
 
   // Error handler - has to be last
-  if ('development' === app.get('env')) {
+  if ('development' === env) {
     app.use(errorHandler());
   }
 };


### PR DESCRIPTION
`app.geg('env')` is already cached in the variable `env`, so is better to use it.
