### PR TITLE
pulling string case fix from upstream

### DIFF
--- a/script-base.js
+++ b/script-base.js
@@ -117,7 +117,7 @@ Generator.prototype.addScriptToIndex = function (script) {
       file: fullPath,
       needle: '<!-- endbuild -->',
       splicable: [
-        '<script src="scripts/' + script.replace('\\', '/') + '.js"></script>'
+        '<script src="scripts/' + script.toLowerCase().replace(/\\/g, '/') + '.js"></script>'
       ]
     });
   } catch (e) {


### PR DESCRIPTION
This fixes a problem with addScriptToIndex,
the files would be generated with String.toLowerCase(); but the paths were not treated the same
when added to the index files.
