### PR TITLE
Added 'required' attribute to login.html inputs

### DIFF
--- a/templates/views/html/partials/login.html
+++ b/templates/views/html/partials/login.html
@@ -11,13 +11,13 @@
       <div class="form-group">
         <label>Email</label>
 
-        <input type="text" name="email" class="form-control" ng-model="user.email">
+        <input type="text" name="email" class="form-control" ng-model="user.email" required>
       </div>
 
       <div class="form-group">
         <label>Password</label>
         
-        <input type="password" name="password" class="form-control" ng-model="user.password">
+        <input type="password" name="password" class="form-control" ng-model="user.password" required>
       </div>
 
       <div class="form-group has-error">


### PR DESCRIPTION
Without adding the required attribute to those inputs, the client-side validation in the help-block below the form will never actually catch and show the error without a request being sent to the server.  By adding the 'required' attribute to each input, it takes advantage of the client-side validation and shows the error already written: ng-show="form.email.$error.required && form.password.$error.required && submitted"
