### PR TITLE
fix(config): fix issue where `config.ip` is undefined in non-production environments

### DIFF
--- a/templates/express/config/env/all.js
+++ b/templates/express/config/env/all.js
@@ -6,6 +6,7 @@ var rootPath = path.normalize(__dirname + '/../../..');
 
 module.exports = {
   root: rootPath,
+  ip: '0.0.0.0',
   port: process.env.PORT || 9000<% if (mongo) { %>,
   mongo: {
     options: {


### PR DESCRIPTION
This is somewhat of a small issue discovered by @chair9design: https://github.com/DaftMonk/generator-angular-fullstack/issues/205#issuecomment-43713129.
`config.ip` is only defined in the production 'env' config file, so when running the server in any other environment (specifically development), no ip is passed to either `app.listen` or  `console.log`(within server.js).

From what i can tell, passing a null hostname to app.listen (which calls [server.listen](http://nodejs.org/api/http.html#http_server_listen_port_hostname_backlog_callback) ) is not an issue. However, since we are directly using this config variable in server.js, it seems like we should default it to something.
