### PR TITLE
Update script-base.js

### DIFF
--- a/script-base.js
+++ b/script-base.js
@@ -117,7 +117,7 @@ Generator.prototype.addScriptToIndex = function (script) {
       file: fullPath,
       needle: '<!-- endbuild -->',
       splicable: [
-        '<script src="scripts/' + script.replace('\\', '/') + '.js"></script>'
+        '<script src="scripts/' + script.replace('\\', '/').toLowerCase() + '.js"></script>'
       ]
     });
   } catch (e) {


### PR DESCRIPTION
Force the script file name to lowercase in the <script> tag to match what is created on the filesystem.

Hopefully this is the correct spot for this fix.

Fixes: https://github.com/DaftMonk/generator-angular-fullstack/issues/236
