### PR TITLE
Fix path to karma.conf.js in Gruntfile.js

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -471,7 +471,7 @@ module.exports = function (grunt) {
     // Test settings
     karma: {
       unit: {
-        configFile: 'karma.conf.js',
+        configFile: 'test/karma.conf.js',
         singleRun: true
       }
     },


### PR DESCRIPTION
Karma task can't run because it looks for karma.conf.js in project's root although the file is in test/. This fixes #247.
