### PR TITLE
fix (gen:endpoint): Remove "s" after "<%= name %>" in endpoint templates

### DIFF
--- a/endpoint/templates/name.controller.js
+++ b/endpoint/templates/name.controller.js
@@ -6,9 +6,9 @@ var <%= classedName %> = require('./<%= name %>.model');<% } %>
 // Get list of <%= name %>s
 exports.index = function(req, res) {<% if (!filters.mongoose) { %>
   res.json([]);<% } %><% if (filters.mongoose) { %>
-  <%= classedName %>.find(function (err, <%= name %>s) {
+  <%= classedName %>.find(function (err, <%= name %>) {
     if(err) { return handleError(res, err); }
-    return res.json(200, <%= name %>s);
+    return res.json(200, <%= name %>);
   });<% } %>
 };<% if (filters.mongoose) { %>
 

--- a/endpoint/templates/name.spec.js
+++ b/endpoint/templates/name.spec.js
@@ -4,11 +4,11 @@ var should = require('should');
 var app = require('../../app');
 var request = require('supertest');
 
-describe('GET /api/<%= name %>s', function() {
+describe('GET /api/<%= name %>', function() {
 
   it('should respond with JSON array', function(done) {
     request(app)
-      .get('/api/<%= name %>s')
+      .get('/api/<%= name %>')
       .expect(200)
       .expect('Content-Type', /json/)
       .end(function(err, res) {


### PR DESCRIPTION
The endpoint generator adds an additional "s" to the controller and test spec files.  This is to remove the additional "s" in the templates.
