### PR TITLE
fix(angular-fullstack:heroku) eliminate almost instant crash

### DIFF
--- a/heroku/index.js
+++ b/heroku/index.js
@@ -81,7 +81,6 @@ Generator.prototype.herokuCreate = function herokuCreate() {
     var output = data.toString();
     this.log(output);
   }.bind(this));
-  child.stdin.write('\n\n');
 };
 
 Generator.prototype.copyProcfile = function copyProcfile() {


### PR DESCRIPTION
Dunno why sending two `\n`'s to `stdin` is a good idea, but it certainly breaks stuff.

Closes #303
