### PR TITLE
feat(app-socket.io) upgrade socket.io and code to use v1.0.6

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -25,7 +25,7 @@
     "passport-google-oauth": "latest",<% } %>
     "composable-middleware": "^0.3.0",
     "connect-mongo": "^0.4.1"<% if(filters.socketio) { %>,
-    "socket.io": "~0.9.16",
+    "socket.io": "~1.0.6",
     "socketio-jwt": "^2.0.2"<% } %>
   },
   "devDependencies": {

--- a/app/templates/client/components/socket(socketio)/socket.service.js
+++ b/app/templates/client/components/socket(socketio)/socket.service.js
@@ -3,29 +3,12 @@
 
 angular.module('<%= scriptAppName %>')
   .factory('socket', function(socketFactory) {
-    var retryInterval = 5000;
-    var retryTimer;
 
-    clearInterval(retryTimer);
-
-    var ioSocket = io.connect('', {
-      'force new connection': true,
-
-      'max reconnection attempts': Infinity,
-
-      'reconnection limit': 10 * 1000,
-
-      // Send auth token on connection
+    // socket.io now auto-configures its connection when we ommit a connection url
+    var ioSocket = io(null, {
+      // Send auth token on connection, you will need to DI the Auth service above
       // 'query': 'token=' + Auth.getToken()
     });
-
-    retryTimer = setInterval(function () {
-      if (!ioSocket.socket.connected &&
-          !ioSocket.socket.connecting &&
-          !ioSocket.socket.reconnecting) {
-        ioSocket.connect();
-      }
-    }, retryInterval);
 
     var socket = socketFactory({
       ioSocket: ioSocket

--- a/app/templates/server/config/_local.env.js
+++ b/app/templates/server/config/_local.env.js
@@ -12,5 +12,7 @@ module.exports = {
   TWITTER_ID: "app-id",
   TWITTER_SECRET: "secret",
   GOOGLE_ID: "app-id",
-  GOOGLE_SECRET: "secret"
+  GOOGLE_SECRET: "secret",
+  // Control debug level for modules using visionmedia/debug
+  // DEBUG: ""
 };

--- a/app/templates/server/config/socketio(socketio).js
+++ b/app/templates/server/config/socketio(socketio).js
@@ -22,24 +22,22 @@ function onConnect(socket) {
 }
 
 module.exports = function (socketio) {
-  // The amount of detail that the server should output to the logger.
-  // 0 - error
-  // 1 - warn
-  // 2 - info
-  // 3 - debug
-  socketio.set('log level', 2);
+  // socket.io (v1.x.x) is powered by debug.
+  // In order to see all the debug output, set DEBUG (in server/config/local.env.js) to including the desired scope.
+  //
+  // ex: DEBUG: "http*,socket.io:socket"
 
   // We can authenticate socket.io users and access their token through socket.handshake.decoded_token
   //
   // 1. You will need to send the token in `client/components/socket/socket.service.js`
   //
   // 2. Require authentication here:
-  // socketio.set('authorization', require('socketio-jwt').authorize({
+  // socketio.use(require('socketio-jwt').authorize({
   //   secret: config.secrets.session,
   //   handshake: true
   // }));
 
-  socketio.sockets.on('connection', function (socket) {
+  socketio.on('connection', function (socket) {
     socket.address = socket.handshake.address.address + ':' +
                      socket.handshake.address.port;
     socket.connectedAt = new Date();


### PR DESCRIPTION
Changes:
- socket.io dependency from 0.9.16 to 1.0.6
- remove reconnection and reconnect limits from the client side, now auto handled by socket.io
- remove socketio.set('log level') from server side, now handled by DEBUG env
- switch socketio.set('authorization', fn) to socketio.use(fn), we use fall through middleware with socket.io now
- add comments informing users of the new changes

closes #339
