### PR TITLE
Fixed express deprecated

### DIFF
--- a/app/templates/server/config/express.js
+++ b/app/templates/server/config/express.js
@@ -26,7 +26,8 @@ module.exports = function(app) {
   app.set('view engine', 'html');<% } %><% if (filters.jade) { %>
   app.set('view engine', 'jade');<% } %>
   app.use(compression());
-  app.use(bodyParser());
+  app.use(bodyParser.urlencoded({ extended: false }));
+  app.use(bodyParser.json());
   app.use(methodOverride());
   app.use(cookieParser());
   <% if (filters.auth) { %>app.use(passport.initialize());<% } %><% if (filters.twitterAuth) { %>
@@ -35,6 +36,8 @@ module.exports = function(app) {
   // We need to enable sessions for passport twitter because its an oauth 1.0 strategy
   app.use(session({
     secret: config.secrets.session,
+    resave: true,
+    saveUninitialized: true,
     store: new mongoStore({
       url: config.mongo.uri,
       collection: 'sessions'


### PR DESCRIPTION
When you run `grunt server` express warn deprecated as below.

```
body-parser deprecated urlencoded: explicitly specify "extended: true" for extended parsing at server/config/express.js:28:22
express-session deprecated undefined resave option; provide resave option at server/config/express.js:39:11
express-session deprecated undefined saveUninitialized option; provide saveUninitialized option at server/config/express.js:39:11
```
