### PR TITLE
refactor(gen:endpoint): configurable route url

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -181,6 +181,9 @@ var AngularFullstackGenerator = yeoman.generators.Base.extend({
     this.config.set('registerRoutesFile', 'server/routes.js');
     this.config.set('routesNeedle', '// Insert routes below');
 
+    this.config.set('routesBase', '/api/');
+    this.config.set('pluralizeRoutes', true);
+
     this.config.set('insertSockets', true);
     this.config.set('registerSocketsFile', 'server/config/socketio.js');
     this.config.set('socketsNeedle', '// Insert sockets below');

--- a/endpoint/index.js
+++ b/endpoint/index.js
@@ -14,11 +14,22 @@ util.inherits(Generator, ScriptBase);
 Generator.prototype.askFor = function askFor() {
   var done = this.async();
   var name = this.name;
+
+  var base = this.config.get('routesBase') || '/api/';
+  if(base.charAt(base.length-1) !== '/') {
+    base = base + '/';
+  }
+
+  // pluralization defaults to true for backwards compat
+  if (this.config.get('pluralizeRoutes') !== false) {
+    name = name + 's';
+  }
+
   var prompts = [
     {
       name: 'route',
       message: 'What will the url of your endpoint to be?',
-      default: '/api/' + name + 's'
+      default: base + name
     }
   ];
 


### PR DESCRIPTION
- Configurable route base, defaults to `/api/`. This only affects the client URL, the backend code will still be written to `server/api`.
- Configurable pluralization of route, defaults to true.

Closes #338
