### PR TITLE
style(app:client:coffee) client-side cleanup of .coffee files

### DIFF
--- a/app/templates/client/app/account(auth)/account(coffee).coffee
+++ b/app/templates/client/app/account(auth)/account(coffee).coffee
@@ -1,35 +1,35 @@
 'use strict'
 
-angular.module('<%= scriptAppName %>')
-  <% if(filters.ngroute) { %>.config ($routeProvider) ->
-    $routeProvider
-    .when('/login',
-      templateUrl: 'app/account/login/login.html'
-      controller: 'LoginCtrl'
-    )
-    .when('/signup',
-      templateUrl: 'app/account/signup/signup.html'
-      controller: 'SignupCtrl'
-    )
-    .when('/settings',
-      templateUrl: 'app/account/settings/settings.html'
-      controller: 'SettingsCtrl',
-      authenticate: true
-    )<% } %><% if(filters.uirouter) { %>.config ($stateProvider) ->
-    $stateProvider
-    .state('login',
-      url: '/login',
-      templateUrl: 'app/account/login/login.html'
-      controller: 'LoginCtrl'
-    )
-    .state('signup',
-      url: '/signup',
-      templateUrl: 'app/account/signup/signup.html'
-      controller: 'SignupCtrl'
-    )
-    .state('settings',
-      url: '/settings',
-      templateUrl: 'app/account/settings/settings.html'
-      controller: 'SettingsCtrl',
-      authenticate: true
-    )<% } %>
+angular.module '<%= scriptAppName %>'
+<% if(filters.ngroute) { %>.config ($routeProvider) ->
+  $routeProvider
+  .when '/login',
+    templateUrl: 'app/account/login/login.html'
+    controller: 'LoginCtrl'
+
+  .when '/signup',
+    templateUrl: 'app/account/signup/signup.html'
+    controller: 'SignupCtrl'
+
+  .when '/settings',
+    templateUrl: 'app/account/settings/settings.html'
+    controller: 'SettingsCtrl'
+    authenticate: true
+<% } %><% if(filters.uirouter) { %>.config ($stateProvider) ->
+  $stateProvider
+  .state 'login',
+    url: '/login'
+    templateUrl: 'app/account/login/login.html'
+    controller: 'LoginCtrl'
+
+  .state 'signup',
+    url: '/signup'
+    templateUrl: 'app/account/signup/signup.html'
+    controller: 'SignupCtrl'
+
+  .state 'settings',
+    url: '/settings'
+    templateUrl: 'app/account/settings/settings.html'
+    controller: 'SettingsCtrl'
+    authenticate: true
+<% } %>

--- a/app/templates/client/app/account(auth)/login/login.controller(coffee).coffee
+++ b/app/templates/client/app/account(auth)/login/login.controller(coffee).coffee
@@ -1,6 +1,7 @@
 'use strict'
 
-angular.module('<%= scriptAppName %>').controller 'LoginCtrl', ($scope, Auth, $location, $window) ->
+angular.module '<%= scriptAppName %>'
+.controller 'LoginCtrl', ($scope, Auth, $location, $window) ->
   $scope.user = {}
   $scope.errors = {}
   $scope.login = (form) ->
@@ -8,12 +9,14 @@ angular.module('<%= scriptAppName %>').controller 'LoginCtrl', ($scope, Auth, $l
 
     if form.$valid
       # Logged in, redirect to home
-      Auth.login(
+      Auth.login
         email: $scope.user.email
         password: $scope.user.password
-      ).then(->
+
+      .then ->
         $location.path '/'
-      ).catch (err) ->
+
+      .catch (err) ->
         $scope.errors.other = err.message
 
   $scope.loginOauth = (provider) ->

--- a/app/templates/client/app/account(auth)/settings/settings.controller(coffee).coffee
+++ b/app/templates/client/app/account(auth)/settings/settings.controller(coffee).coffee
@@ -1,14 +1,17 @@
 'use strict'
 
-angular.module('<%= scriptAppName %>').controller 'SettingsCtrl', ($scope, User, Auth) ->
+angular.module '<%= scriptAppName %>'
+.controller 'SettingsCtrl', ($scope, User, Auth) ->
   $scope.errors = {}
   $scope.changePassword = (form) ->
     $scope.submitted = true
 
     if form.$valid
-      Auth.changePassword($scope.user.oldPassword, $scope.user.newPassword).then(->
+      Auth.changePassword $scope.user.oldPassword, $scope.user.newPassword
+      .then ->
         $scope.message = 'Password successfully changed.'
-      ).catch ->
+
+      .catch ->
         form.password.$setValidity 'mongoose', false
         $scope.errors.other = 'Incorrect password'
         $scope.message = ''

--- a/app/templates/client/app/account(auth)/signup/signup.controller(coffee).coffee
+++ b/app/templates/client/app/account(auth)/signup/signup.controller(coffee).coffee
@@ -1,6 +1,7 @@
 'use strict'
 
-angular.module('<%= scriptAppName %>').controller 'SignupCtrl', ($scope, Auth, $location, $window) ->
+angular.module '<%= scriptAppName %>'
+.controller 'SignupCtrl', ($scope, Auth, $location, $window) ->
   $scope.user = {}
   $scope.errors = {}
   $scope.register = (form) ->
@@ -8,14 +9,15 @@ angular.module('<%= scriptAppName %>').controller 'SignupCtrl', ($scope, Auth, $
 
     if form.$valid
       # Account created, redirect to home
-      Auth.createUser(
+      Auth.createUser
         name: $scope.user.name
         email: $scope.user.email
         password: $scope.user.password
-      ).then(->
+
+      .then ->
         $location.path '/'
 
-      ).catch (err) ->
+      .catch (err) ->
         err = err.data
         $scope.errors = {}
 

--- a/app/templates/client/app/admin(auth)/admin(coffee).coffee
+++ b/app/templates/client/app/admin(auth)/admin(coffee).coffee
@@ -1,15 +1,15 @@
 'use strict'
 
-angular.module('<%= scriptAppName %>')
-  <% if(filters.ngroute) { %>.config ($routeProvider) ->
-    $routeProvider
-    .when('/admin',
-      templateUrl: 'app/admin/admin.html'
-      controller: 'AdminCtrl'
-    )<% } %><% if(filters.uirouter) { %>.config ($stateProvider) ->
-    $stateProvider
-    .state('admin',
-      url: '/admin',
-      templateUrl: 'app/admin/admin.html'
-      controller: 'AdminCtrl'
-    )<% } %>
+angular.module '<%= scriptAppName %>'
+<% if(filters.ngroute) { %>.config ($routeProvider) ->
+  $routeProvider
+  .when '/admin',
+    templateUrl: 'app/admin/admin.html'
+    controller: 'AdminCtrl'
+<% } %><% if(filters.uirouter) { %>.config ($stateProvider) ->
+  $stateProvider
+  .state 'admin',
+    url: '/admin'
+    templateUrl: 'app/admin/admin.html'
+    controller: 'AdminCtrl'
+<% } %>

--- a/app/templates/client/app/admin(auth)/admin.controller(coffee).coffee
+++ b/app/templates/client/app/admin(auth)/admin.controller(coffee).coffee
@@ -1,10 +1,13 @@
 'use strict'
 
-angular.module('<%= scriptAppName %>').controller 'AdminCtrl', ($scope, $http, Auth, User) ->
-  $http.get('/api/users').success (users) ->
+angular.module '<%= scriptAppName %>'
+.controller 'AdminCtrl', ($scope, $http, Auth, User) ->
+
+  $http.get '/api/users'
+  .success (users) ->
     $scope.users = users
 
   $scope.delete = (user) ->
     User.remove id: user._id
     angular.forEach $scope.users, (u, i) ->
-      $scope.users.splice i, 1  if u is user
+      $scope.users.splice i, 1 if u is user

--- a/app/templates/client/app/app(coffee).coffee
+++ b/app/templates/client/app/app(coffee).coffee
@@ -1,40 +1,39 @@
 'use strict'
 
-angular.module('<%= scriptAppName %>', [<%= angularModules %>])
-  <% if(filters.ngroute) { %>.config (($routeProvider, $locationProvider<% if(filters.auth) { %>, $httpProvider<% } %>) ->
-    $routeProvider
-    .otherwise
-        redirectTo: '/'
+angular.module '<%= scriptAppName %>', [<%= angularModules %>]
+<% if(filters.ngroute) { %>.config ($routeProvider, $locationProvider<% if(filters.auth) { %>, $httpProvider<% } %>) ->
+  $routeProvider
+  .otherwise
+    redirectTo: '/'
 
-    $locationProvider.html5Mode true<% if(filters.auth) { %>
-    $httpProvider.interceptors.push 'authInterceptor'<% } %>
-  )<% } %><% if(filters.uirouter) { %>.config (($stateProvider, $urlRouterProvider, $locationProvider<% if(filters.auth) { %>, $httpProvider<% } %>) ->
-    $urlRouterProvider
-    .otherwise('/')
+  $locationProvider.html5Mode true<% if(filters.auth) { %>
+  $httpProvider.interceptors.push 'authInterceptor'<% } %>
+<% } %><% if(filters.uirouter) { %>.config ($stateProvider, $urlRouterProvider, $locationProvider<% if(filters.auth) { %>, $httpProvider<% } %>) ->
+  $urlRouterProvider
+  .otherwise '/'
 
-    $locationProvider.html5Mode true<% if(filters.auth) { %>
-    $httpProvider.interceptors.push 'authInterceptor'<% } %>
-  )<% } %><% if(filters.auth) { %>
-  .factory('authInterceptor', ($rootScope, $q, $cookieStore, $location) ->
-    # Add authorization token to headers
-    request: (config) ->
-      config.headers = config.headers or {}
-      config.headers.Authorization = 'Bearer ' + $cookieStore.get('token')  if $cookieStore.get('token')
-      config
+  $locationProvider.html5Mode true<% if(filters.auth) { %>
+  $httpProvider.interceptors.push 'authInterceptor'<% } %>
+<% } %><% if(filters.auth) { %>
+.factory 'authInterceptor', ($rootScope, $q, $cookieStore, $location) ->
+  # Add authorization token to headers
+  request: (config) ->
+    config.headers = config.headers or {}
+    config.headers.Authorization = 'Bearer ' + $cookieStore.get 'token' if $cookieStore.get 'token'
+    config
 
-    # Intercept 401s and redirect you to login
-    responseError: (response) ->
-      if response.status is 401
-        $location.path '/login'
-        # remove any stale tokens
-        $cookieStore.remove 'token'
-        $q.reject response
-      else
-        $q.reject response
-  )
-  .run (($rootScope, $location, Auth) ->
-    # Redirect to login if route requires auth and you're not logged in
-    $rootScope.$on <% if(filters.ngroute) { %>'$routeChangeStart'<% } %><% if(filters.uirouter) { %>'$stateChangeStart'<% } %>, (event, next) ->
-      Auth.isLoggedInAsync (loggedIn) ->
-        $location.path "/login"  if next.authenticate and not loggedIn
-  )<% } %>
+  # Intercept 401s and redirect you to login
+  responseError: (response) ->
+    if response.status is 401
+      $location.path '/login'
+      # remove any stale tokens
+      $cookieStore.remove 'token'
+
+    $q.reject response
+
+.run ($rootScope, $location, Auth) ->
+  # Redirect to login if route requires auth and you're not logged in
+  $rootScope.$on <% if(filters.ngroute) { %>'$routeChangeStart'<% } %><% if(filters.uirouter) { %>'$stateChangeStart'<% } %>, (event, next) ->
+    Auth.isLoggedInAsync (loggedIn) ->
+      $location.path "/login" if next.authenticate and not loggedIn
+<% } %>

--- a/app/templates/client/app/main/main(coffee).coffee
+++ b/app/templates/client/app/main/main(coffee).coffee
@@ -1,15 +1,15 @@
 'use strict'
 
-angular.module('<%= scriptAppName %>')
-  <% if(filters.ngroute) { %>.config ($routeProvider) ->
-    $routeProvider
-    .when('/',
-      templateUrl: 'app/main/main.html'
-      controller: 'MainCtrl'
-    )<% } %><% if(filters.uirouter) { %>.config ($stateProvider) ->
-    $stateProvider
-    .state('main',
-      url: '/',
-      templateUrl: 'app/main/main.html'
-      controller: 'MainCtrl'
-    )<% } %>
+angular.module '<%= scriptAppName %>'
+<% if(filters.ngroute) { %>.config ($routeProvider) ->
+  $routeProvider
+  .when '/',
+    templateUrl: 'app/main/main.html'
+    controller: 'MainCtrl'
+<% } %><% if(filters.uirouter) { %>.config ($stateProvider) ->
+  $stateProvider
+  .state 'main',
+    url: '/'
+    templateUrl: 'app/main/main.html'
+    controller: 'MainCtrl'
+<% } %>

--- a/app/templates/client/app/main/main.controller(coffee).coffee
+++ b/app/templates/client/app/main/main.controller(coffee).coffee
@@ -1,6 +1,7 @@
 'use strict'
 
-angular.module('<%= scriptAppName %>').controller 'MainCtrl', ($scope, $http<% if(filters.socketio) { %>, socket<% } %>) ->
+angular.module '<%= scriptAppName %>'
+.controller 'MainCtrl', ($scope, $http<% if(filters.socketio) { %>, socket<% } %>) ->
   $scope.awesomeThings = []
 
   $http.get('/api/things').success (awesomeThings) ->

--- a/app/templates/client/app/main/main.controller.spec(coffee).coffee
+++ b/app/templates/client/app/main/main.controller.spec(coffee).coffee
@@ -3,15 +3,15 @@
 describe 'Controller: MainCtrl', ->
 
   # load the controller's module
-  beforeEach module('<%= scriptAppName %>')<% if(filters.socketio) {%>
-  beforeEach module('socketMock')<% } %>
+  beforeEach module '<%= scriptAppName %>' <% if(filters.socketio) {%>
+  beforeEach module 'socketMock' <% } %>
 
   MainCtrl = undefined
   scope = undefined
   $httpBackend = undefined
 
   # Initialize the controller and a mock scope
-  beforeEach inject((_$httpBackend_, $controller, $rootScope) ->
+  beforeEach inject (_$httpBackend_, $controller, $rootScope) ->
     $httpBackend = _$httpBackend_
     $httpBackend.expectGET('/api/things').respond [
       'HTML5 Boilerplate'
@@ -20,10 +20,8 @@ describe 'Controller: MainCtrl', ->
       'Express'
     ]
     scope = $rootScope.$new()
-    MainCtrl = $controller('MainCtrl',
+    MainCtrl = $controller 'MainCtrl',
       $scope: scope
-    )
-  )
 
   it 'should attach a list of things to the scope', ->
     $httpBackend.flush()

--- a/app/templates/client/components/auth(auth)/user.service(coffee).coffee
+++ b/app/templates/client/components/auth(auth)/user.service(coffee).coffee
@@ -1,6 +1,7 @@
 'use strict'
 
-angular.module('<%= scriptAppName %>').factory 'User', ($resource) ->
+angular.module '<%= scriptAppName %>'
+.factory 'User', ($resource) ->
   $resource '/api/users/:id/:controller',
     id: '@_id'
   ,

--- a/app/templates/client/components/mongoose-error(auth)/mongoose-error.directive(coffee).coffee
+++ b/app/templates/client/components/mongoose-error(auth)/mongoose-error.directive(coffee).coffee
@@ -3,7 +3,8 @@
 ###
 Removes server error when user updates input
 ###
-angular.module('<%= scriptAppName %>').directive 'mongooseError', ->
+angular.module '<%= scriptAppName %>'
+.directive 'mongooseError', ->
   restrict: 'A'
   require: 'ngModel'
   link: (scope, element, attrs, ngModel) ->

--- a/app/templates/client/components/navbar/navbar.controller(coffee).coffee
+++ b/app/templates/client/components/navbar/navbar.controller(coffee).coffee
@@ -1,6 +1,7 @@
 'use strict'
 
-angular.module('<%= scriptAppName %>').controller 'NavbarCtrl', ($scope, $location<% if(filters.auth) {%>, Auth<% } %>) ->
+angular.module '<%= scriptAppName %>'
+.controller 'NavbarCtrl', ($scope, $location<% if(filters.auth) {%>, Auth<% } %>) ->
   $scope.menu = [
     title: 'Home'
     link: '/'
@@ -9,7 +10,7 @@ angular.module('<%= scriptAppName %>').controller 'NavbarCtrl', ($scope, $locati
   $scope.isLoggedIn = Auth.isLoggedIn
   $scope.isAdmin = Auth.isAdmin
   $scope.getCurrentUser = Auth.getCurrentUser
-  
+
   $scope.logout = ->
     Auth.logout()
     $location.path '/login'<% } %>

--- a/app/templates/client/components/socket(socketio)/socket.mock(coffee).coffee
+++ b/app/templates/client/components/socket(socketio)/socket.mock(coffee).coffee
@@ -1,6 +1,7 @@
 'use strict'
 
-angular.module('socketMock', []).factory 'socket', ->
+angular.module 'socketMock', []
+.factory 'socket', ->
   socket:
     connect: ->
 

--- a/app/templates/client/components/socket(socketio)/socket.service(coffee).coffee
+++ b/app/templates/client/components/socket(socketio)/socket.service(coffee).coffee
@@ -1,23 +1,23 @@
-# global io 
+# global io
 
 'use strict'
 
-angular.module('<%= scriptAppName %>').factory 'socket', (socketFactory) ->
+angular.module '<%= scriptAppName %>'
+.factory 'socket', (socketFactory) ->
   retryInterval = 5000
   retryTimer = undefined
   clearInterval retryTimer
-  ioSocket = io.connect('',
+  ioSocket = io.connect '',
     'force new connection': true
     'max reconnection attempts': Infinity
     'reconnection limit': 10 * 1000
     # Send auth token on connection
     # 'query': 'token=' + Auth.getToken()
-  )
-  
-  retryTimer = setInterval(->
-    ioSocket.connect()  if not ioSocket.socket.connected and not ioSocket.socket.connecting and not ioSocket.socket.reconnecting
-  , retryInterval)
-  socket = socketFactory(ioSocket: ioSocket)
+
+  retryTimer = setInterval ->
+    ioSocket.connect() if not ioSocket.socket.connected and not ioSocket.socket.connecting and not ioSocket.socket.reconnecting
+  , retryInterval
+  socket = socketFactory ioSocket: ioSocket
 
   socket: socket
 
@@ -29,19 +29,18 @@ angular.module('<%= scriptAppName %>').factory 'socket', (socketFactory) ->
 
   @param {String} modelName
   @param {Array} array
-  @param {Function} cb
+  @param {Function} callback
   ###
-  syncUpdates: (modelName, array, cb) ->
-    cb = cb or angular.noop
+  syncUpdates: (modelName, array, callback) ->
 
     ###
     Syncs item creation/updates on 'model:save'
     ###
     socket.on modelName + ':save', (item) ->
-      oldItem = _.find(array,
+      oldItem = _.find array,
         _id: item._id
-      )
-      index = array.indexOf(oldItem)
+
+      index = array.indexOf oldItem
       event = 'created'
 
       # replace oldItem if it exists
@@ -51,7 +50,8 @@ angular.module('<%= scriptAppName %>').factory 'socket', (socketFactory) ->
         event = 'updated'
       else
         array.push item
-      cb event, item, array
+
+      callback? event, item, array
 
     ###
     Syncs removed items on 'model:remove'
@@ -61,7 +61,7 @@ angular.module('<%= scriptAppName %>').factory 'socket', (socketFactory) ->
       _.remove array,
         _id: item._id
 
-      cb event, item, array
+      callback? event, item, array
 
   ###
   Removes listeners for a models updates on the socket


### PR DESCRIPTION
#### Changes include:
- redundant parentheses and commas removed,
- `.bind(this)` replaced with  `=>`,
- added function checks to all callbacks (vel. `callback? value`); It may be replaced by `(callback=angular.noop) ->` if that makes more sense(?),
- all `cb`'s renamed to `callback` (I'd prefer `cb`, but `callback` seems more verbose),
- some new lines added to improve readability,
- consistency fixes:
  - `.{config,controller,factory,directive,run}` now are always consistently in a new line,
  - all method calls are now on the same indentation level as their object.
