### PR TITLE
fix(app:server:thing.controller): missing `res` param for handleError added

### DIFF
--- a/app/templates/server/api/thing/thing.controller.js
+++ b/app/templates/server/api/thing/thing.controller.js
@@ -62,11 +62,11 @@ exports.create = function(req, res) {
 exports.update = function(req, res) {
   if(req.body._id) { delete req.body._id; }
   Thing.findById(req.params.id, function (err, thing) {
-    if (err) { return handleError(err); }
+    if (err) { return handleError(res, err); }
     if(!thing) { return res.send(404); }
     var updated = _.merge(thing, req.body);
     updated.save(function (err) {
-      if (err) { return handleError(err); }
+      if (err) { return handleError(res, err); }
       return res.json(200, thing);
     });
   });


### PR DESCRIPTION
Missing parameter added to fn call.
