### PR TITLE
fix(settings): show "change password" only for local account

### DIFF
--- a/app/templates/client/app/account(auth)/settings/settings(html).html
+++ b/app/templates/client/app/account(auth)/settings/settings(html).html
@@ -1,6 +1,6 @@
 <div ng-include="'components/navbar/navbar.html'"></div>
 
-<div class="container">
+<div class="container" ng-show="isPasswordChangeable()">
   <div class="row">
     <div class="col-sm-12">
       <h1>Change Password</h1>
@@ -34,6 +34,14 @@
 
         <button class="btn btn-lg btn-primary" type="submit">Save changes</button>
       </form>
+    </div>
+  </div>
+</div>
+
+<div class="container" ng-hide="isPasswordChangeable()">
+  <div class="row">
+    <div class="col-sm-12">
+      <h1>Your password can not be changed</h1>
     </div>
   </div>
 </div>

--- a/app/templates/client/app/account(auth)/settings/settings(jade).jade
+++ b/app/templates/client/app/account(auth)/settings/settings(jade).jade
@@ -1,5 +1,5 @@
 div(ng-include='"components/navbar/navbar.html"')
-.container
+.container(ng-show="isPasswordChangeable()")
   .row
     .col-sm-12
       h1 Change Password
@@ -19,3 +19,8 @@ div(ng-include='"components/navbar/navbar.html"')
         p.help-block  {{ message }}
 
         button.btn.btn-lg.btn-primary(type='submit') Save changes
+
+.container(ng-hide="isPasswordChangeable()")
+  .row
+    .col-sm-12
+      h1 Your password can not be changed

--- a/app/templates/client/app/account(auth)/settings/settings.controller(coffee).coffee
+++ b/app/templates/client/app/account(auth)/settings/settings.controller(coffee).coffee
@@ -2,6 +2,7 @@
 
 angular.module('<%= scriptAppName %>').controller 'SettingsCtrl', ($scope, User, Auth) ->
   $scope.errors = {}
+  $scope.isPasswordChangeable = Auth.isPasswordChangeable
   $scope.changePassword = (form) ->
     $scope.submitted = true
 

--- a/app/templates/client/app/account(auth)/settings/settings.controller(js).js
+++ b/app/templates/client/app/account(auth)/settings/settings.controller(js).js
@@ -3,6 +3,7 @@
 angular.module('<%= scriptAppName %>')
   .controller('SettingsCtrl', function ($scope, User, Auth) {
     $scope.errors = {};
+    $scope.isPasswordChangeable = Auth.isPasswordChangeable;
 
     $scope.changePassword = function(form) {
       $scope.submitted = true;

--- a/app/templates/client/components/auth(auth)/auth.service(coffee).coffee
+++ b/app/templates/client/components/auth(auth)/auth.service(coffee).coffee
@@ -131,3 +131,10 @@ angular.module('<%= scriptAppName %>').factory 'Auth', ($location, $rootScope, $
   ###
   getToken: ->
     $cookieStore.get 'token'
+
+  ###
+  Check is password is changeable
+  (only local account have changeable password)
+  ###
+  isPasswordChangeable: ->
+    currentUser.provider is 'local'

--- a/app/templates/client/components/auth(auth)/auth.service(js).js
+++ b/app/templates/client/components/auth(auth)/auth.service(js).js
@@ -141,6 +141,15 @@ angular.module('<%= scriptAppName %>')
        */
       getToken: function() {
         return $cookieStore.get('token');
+      },
+
+      /**
+       * Check is password is changeable
+       * (only local account have changeable password)
+       */
+      isPasswordChangeable : function(){
+        return currentUser.provider === 'local';
       }
+
     };
   });


### PR DESCRIPTION
fix(settings): show « change password » only for local account and hide
for account signed up over social network
- add new method `isPasswordChangeable` in Auth.service.js;
- modify settings view to show « change password » only for local
  created account;

Closes #343
