### PR TITLE
fix(socketio): fallback for when `socket.handshake.address` is not provided

### DIFF
--- a/app/templates/server/config/_local.env.js
+++ b/app/templates/server/config/_local.env.js
@@ -6,13 +6,18 @@
 // This file should not be tracked by git.
 
 module.exports = {
-  SESSION_SECRET: "<%= _.slugify(appname) + '-secret' %>",
-  FACEBOOK_ID: "app-id",
-  FACEBOOK_SECRET: "secret",
-  TWITTER_ID: "app-id",
-  TWITTER_SECRET: "secret",
-  GOOGLE_ID: "app-id",
-  GOOGLE_SECRET: "secret",
+  DOMAIN:           'http://localhost:9000',
+  SESSION_SECRET:   "<%= _.slugify(appname) + '-secret' %>",
+
+  FACEBOOK_ID:      'app-id',
+  FACEBOOK_SECRET:  'secret',
+
+  TWITTER_ID:       'app-id',
+  TWITTER_SECRET:   'secret',
+
+  GOOGLE_ID:        'app-id',
+  GOOGLE_SECRET:    'secret',
+
   // Control debug level for modules using visionmedia/debug
   // DEBUG: ""
 };

--- a/app/templates/server/config/environment/index.js
+++ b/app/templates/server/config/environment/index.js
@@ -44,19 +44,19 @@ var all = {
   facebook: {
     clientID:     process.env.FACEBOOK_ID || 'id',
     clientSecret: process.env.FACEBOOK_SECRET || 'secret',
-    callbackURL:  'http://localhost:9000/auth/facebook/callback'
+    callbackURL:  process.env.DOMAIN + '/auth/facebook/callback'
   },
 <% } %><% if(filters.twitterAuth) { %>
   twitter: {
     clientID:     process.env.TWITTER_ID || 'id',
     clientSecret: process.env.TWITTER_SECRET || 'secret',
-    callbackURL:  'http://localhost:9000/auth/twitter/callback'
+    callbackURL:  process.env.DOMAIN + '/auth/twitter/callback'
   },
 <% } %><% if(filters.googleAuth) { %>
   google: {
     clientID:     process.env.GOOGLE_ID || 'id',
     clientSecret: process.env.GOOGLE_SECRET || 'secret',
-    callbackURL:  'http://localhost:9000/auth/google/callback'
+    callbackURL:  process.env.DOMAIN + '/auth/google/callback'
   }<% } %>
 };
 

--- a/app/templates/server/config/socketio(socketio).js
+++ b/app/templates/server/config/socketio(socketio).js
@@ -38,8 +38,10 @@ module.exports = function (socketio) {
   // }));
 
   socketio.on('connection', function (socket) {
-    socket.address = socket.handshake.address.address + ':' +
-                     socket.handshake.address.port;
+    socket.address = socket.handshake.address !== null ?
+            socket.handshake.address.address + ':' + socket.handshake.address.port :
+            process.env.DOMAIN;
+
     socket.connectedAt = new Date();
 
     // Call onDisconnect.


### PR DESCRIPTION
On some servers (ex. `heroku`), property `socket.handshake.address` is `null`.

This fix, adds fallback to the `DOMAIN` set in `server/config/_local.env.js`.

Also:
- eliminates need to paste `DOMAIN` for each passport Strategy, and 
- fixes bug where authenticating on `localhost` would result in an external redirect.
