### PR TITLE
fix(app-dependency): change ngmin to ng-annotate

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -316,7 +316,7 @@ module.exports = function (grunt) {
 
     // Allow the use of non-minsafe AngularJS files. Automatically makes it
     // minsafe compatible so Uglify does not destroy the ng references
-    ngmin: {
+    ngAnnotate: {
       dist: {
         files: [{
           expand: true,
@@ -782,7 +782,7 @@ module.exports = function (grunt) {
     'autoprefixer',
     'ngtemplates',
     'concat',
-    'ngmin',
+    'ngAnnotate',
     'copy:dist',
     'cdnify',
     'cssmin',

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -47,7 +47,7 @@
     "grunt-contrib-less": "^0.11.0",<% } %>
     "grunt-google-cdn": "~0.4.0",
     "grunt-newer": "~0.7.0",
-    "grunt-ngmin": "~0.0.3",
+    "grunt-ng-annotate": "^0.2.3",
     "grunt-rev": "~0.1.0",
     "grunt-svgmin": "~0.4.0",
     "grunt-usemin": "~2.1.1",


### PR DESCRIPTION
ngmin is now deprecated, the author has suggested ng-annotate as a replacement

Changes:
- switch dev-dependency from grunt-ngmin to grunt-ng-annotate
- use ngAnnotate config instead of ngmin
