### PR TITLE
Update grunt-protractor-runner from 0.2.4 to 1.1.0

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -56,7 +56,7 @@
     "grunt-nodemon": "~0.2.0",
     "grunt-angular-templates": "^0.5.4",
     "grunt-dom-munger": "^3.4.0",
-    "grunt-protractor-runner": "^0.2.4",
+    "grunt-protractor-runner": "^1.1.0",
     "grunt-asset-injector": "^0.1.0",
     "grunt-karma": "~0.8.2",
     "grunt-mocha-test": "~0.10.2",<% if(filters.sass) { %>

--- a/test/fixtures/package.json
+++ b/test/fixtures/package.json
@@ -56,7 +56,7 @@
     "grunt-nodemon": "~0.2.0",
     "grunt-angular-templates": "^0.5.4",
     "grunt-dom-munger": "^3.4.0",
-    "grunt-protractor-runner": "^0.2.4",
+    "grunt-protractor-runner": "^1.1.0",
     "grunt-asset-injector": "^0.1.0",
     "grunt-karma": "~0.8.2",
     "grunt-mocha-test": "~0.10.2",


### PR DESCRIPTION
[Protractor](https://github.com/angular/protractor) v1.0.0 has been released. To take advantage of this, we need to update [grunt-protractor-runner](https://github.com/teerapap/grunt-protractor-runner) to version 1.1.0.

All tests from `npm test` passed, although I didn't add any new tests. Also, I confirmed that after scaffolding out a new project, the following passed successfully:

``` bash
$ mongod --config /usr/local/etc/mongod.conf
// New shell
$ grunt test:server
$ grunt test:client
$ npm run update-webdriver
$ grunt test:e2e
```

Notes:
1. When I scaffolded out the project, I accepted all defaults.
2. I do not have protractor installed globally.
3. In a separate shell, I ran `mongod --config /usr/local/etc/mongod.conf` to get MongoDB running since I'm on OS X and installed it using Homebrew.
