### PR TITLE
Clear retry interval before setting it to undefined

### DIFF
--- a/app/templates/client/components/socket(socketio)/socket.service(coffee).coffee
+++ b/app/templates/client/components/socket(socketio)/socket.service(coffee).coffee
@@ -5,8 +5,8 @@
 angular.module '<%= scriptAppName %>'
 .factory 'socket', (socketFactory) ->
   retryInterval = 5000
-  retryTimer = undefined
   clearInterval retryTimer
+  retryTimer = undefined
   ioSocket = io.connect '',
     'force new connection': true
     'max reconnection attempts': Infinity


### PR DESCRIPTION
It seems you run `clearInterval` to stop the timer but you set it to `undefined` just before you run `clearInterval` which essentially makes the line useless.
