### PR TITLE
fix(gen): Fixed missing `oauth` prop in `.yo-rc.json` after 2.0.5 update

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -42,6 +42,16 @@ var AngularFullstackGenerator = yeoman.generators.Base.extend({
         default: true,
       }], function (answers) {
         this.skipConfig = answers.skipConfig;
+
+        // NOTE: temp(?) fix for #403
+        if(typeof this.oauth==='undefined') {
+          var strategies = Object.keys(this.filters).filter(function(key) {
+            return key.match(/Auth$/) && key;
+          });
+
+          if(strategies.length) this.config.set('oauth', true);
+        }
+
         cb();
       }.bind(this));
     } else {


### PR DESCRIPTION
Added proper update-process handling of `filters.oauth` property introduced [here](https://github.com/DaftMonk/generator-angular-fullstack/commit/316bd9dd3632622b0fb434cacfc4150f01d18e4c#diff-2018087f584c4398b5c3a23fc0e5f9dbR169).

Closes #403
