### PR TITLE
fixed body-parser version to play well with multipart forms

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "express": "~4.0.0",
     "morgan": "~1.0.0",
-    "body-parser": "~1.0.0",
+    "body-parser": "~1.5.0",
     "method-override": "~1.0.0",
     "static-favicon": "~1.0.1",
     "cookie-parser": "~1.0.1",

--- a/test/fixtures/package.json
+++ b/test/fixtures/package.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "express": "~4.0.0",
     "morgan": "~1.0.0",
-    "body-parser": "~1.0.0",
+    "body-parser": "~1.5.0",
     "method-override": "~1.0.0",
     "static-favicon": "~1.0.1",
     "cookie-parser": "~1.0.1",


### PR DESCRIPTION
Body Parser 1.0.0 does not play well with Multer (and probably either with other multipart middleware).
See #386 for more details.
