### PR TITLE
fix(gen:app:socket): use `''` instead `null` as URL to open ioSocket

### DIFF
--- a/app/templates/client/components/socket(socketio)/socket.service(coffee).coffee
+++ b/app/templates/client/components/socket(socketio)/socket.service(coffee).coffee
@@ -6,7 +6,7 @@ angular.module '<%= scriptAppName %>'
 .factory 'socket', (socketFactory) ->
 
   # socket.io now auto-configures its connection when we omit a connection url
-  ioSocket = io null,
+  ioSocket = io '',
     'reconnection limit': 10 * 1000
     # Send auth token on connection, you will need to DI the Auth service above
     # 'query': 'token=' + Auth.getToken()

--- a/app/templates/client/components/socket(socketio)/socket.service.js
+++ b/app/templates/client/components/socket(socketio)/socket.service.js
@@ -5,7 +5,7 @@ angular.module('<%= scriptAppName %>')
   .factory('socket', function(socketFactory) {
 
     // socket.io now auto-configures its connection when we ommit a connection url
-    var ioSocket = io(null, {
+    var ioSocket = io('', {
       // Send auth token on connection, you will need to DI the Auth service above
       // 'query': 'token=' + Auth.getToken()
     });


### PR DESCRIPTION
With socket.io 1.0.6, when opening ioSocket with null as URL, io() will
omit the option object. As a result, `query` and Auth Token will not be
sent through handshake.
