### PR TITLE
removed unnecessary line in non-sass projects

### DIFF
--- a/app/templates/_.gitignore
+++ b/app/templates/_.gitignore
@@ -1,7 +1,7 @@
 node_modules
 public
-.tmp
-.sass-cache
+.tmp<% if(filters.sass) { %>
+.sass-cache<% } %>
 client/bower_components
 dist
 /server/config/local.env.js


### PR DESCRIPTION
added a filter to check if the sass-cache folder is needed to be ignored in the .gitignore file
