### PR TITLE
fix(gen:app:navbar): improve navbar component when using ui-router

### DIFF
--- a/app/templates/client/components/navbar/navbar(html).html
+++ b/app/templates/client/components/navbar/navbar(html).html
@@ -11,18 +11,18 @@
     </div>
     <div collapse="isCollapsed" class="navbar-collapse collapse" id="navbar-main">
       <ul class="nav navbar-nav">
-        <li ng-repeat="item in menu" ng-class="{active: isActive(item.link)}">
-            <a ng-href="{{item.link}}">{{item.title}}</a>
+        <li ng-repeat="item in menu" <% if(filters.uirouter) { %>ui-sref-active="active"<% } else { %>ng-class="{active: isActive(item.link)}"<% } %>>
+            <a <% if(filters.uirouter) { %>ui-sref="{{item.state}}"<% } else { %>ng-href="{{item.link}}"<% } %>>{{item.title}}</a>
         </li><% if(filters.auth) { %>
-        <li ng-show="isAdmin()" ng-class="{active: isActive('/admin')}"><a href="/admin">Admin</a></li><% } %>
+        <li ng-show="isAdmin()" <% if(filters.uirouter) { %>ui-sref-active="active"<% } else { %>ng-class="{active: isActive('/admin')}"<% } %>><a <% if(filters.uirouter) { %>ui-sref="admin"<% } else { %>href="/admin"<% } %>>Admin</a></li><% } %>
       </ul><% if(filters.auth) { %>
 
       <ul class="nav navbar-nav navbar-right">
-        <li ng-hide="isLoggedIn()" ng-class="{active: isActive('/signup')}"><a href="/signup">Sign up</a></li>
-        <li ng-hide="isLoggedIn()" ng-class="{active: isActive('/login')}"><a href="/login">Login</a></li>
+        <li ng-hide="isLoggedIn()" <% if(filters.uirouter) { %>ui-sref-active="active"<% } else { %>ng-class="{active: isActive('/signup')}"<% } %>><a <% if(filters.uirouter) { %>ui-sref="signup"<% } else { %>href="/signup"<% } %>>Sign up</a></li>
+        <li ng-hide="isLoggedIn()" <% if(filters.uirouter) { %>ui-sref-active="active"<% } else { %>ng-class="{active: isActive('/login')}"<% } %>><a <% if(filters.uirouter) { %>ui-sref="login"<% } else { %>href="/login"<% } %>>Login</a></li>
         <li ng-show="isLoggedIn()"><p class="navbar-text">Hello {{ getCurrentUser().name }}</p> </li>
-        <li ng-show="isLoggedIn()" ng-class="{active: isActive('/settings')}"><a href="/settings"><span class="glyphicon glyphicon-cog"></span></a></li>
-        <li ng-show="isLoggedIn()" ng-class="{active: isActive('/logout')}"><a href="" ng-click="logout()">Logout</a></li>
+        <li ng-show="isLoggedIn()" <% if(filters.uirouter) { %>ui-sref-active="active"<% } else { %>ng-class="{active: isActive('/settings')}"<% } %>><a <% if(filters.uirouter) { %>ui-sref="settings"<% } else { %>href="/settings"<% } %>><span class="glyphicon glyphicon-cog"></span></a></li>
+        <li ng-show="isLoggedIn()"><a href="" ng-click="logout()">Logout</a></li>
       </ul><% } %>
     </div>
   </div>

--- a/app/templates/client/components/navbar/navbar(jade).jade
+++ b/app/templates/client/components/navbar/navbar(jade).jade
@@ -10,25 +10,25 @@ div.navbar.navbar-default.navbar-static-top(ng-controller='NavbarCtrl')
 
     div#navbar-main.navbar-collapse.collapse(collapse='isCollapsed')
       ul.nav.navbar-nav
-        li(ng-repeat='item in menu', ng-class='{active: isActive(item.link)}')
-          a(ng-href='{{item.link}}') {{item.title}}<% if(filters.auth) { %>
+        li(ng-repeat='item in menu', <% if(filters.uirouter) { %>ui-sref-active='active'<% } else { %>ng-class='{active: isActive(item.link)}'<% } %>)
+          a(<% if(filters.uirouter) { %>ui-sref='{{item.state}}'<% } else { %>ng-href='{{item.link}}'<% } %>) {{item.title}}<% if(filters.auth) { %>
 
-        li(ng-show='isAdmin()', ng-class='{active: isActive("/admin")}')
-          a(href='/admin') Admin<% } %><% if(filters.auth) { %>
+        li(ng-show='isAdmin()', <% if(filters.uirouter) { %>ui-sref-active='active'<% } else { %>ng-class='{active: isActive("/admin")}'<% } %>)
+          a(<% if(filters.uirouter) { %>ui-sref='admin'<% } else { %>href='/admin'<% } %>) Admin
 
       ul.nav.navbar-nav.navbar-right
-        li(ng-hide='isLoggedIn()', ng-class='{active: isActive("/signup")}')
-          a(href='/signup') Sign up
+        li(ng-hide='isLoggedIn()', <% if(filters.uirouter) { %>ui-sref-active='active'<% } else { %>ng-class='{active: isActive("/signup")}'<% } %>)
+          a(<% if(filters.uirouter) { %>ui-sref='signup'<% } else { %>href='/signup'<% } %>) Sign up
 
-        li(ng-hide='isLoggedIn()', ng-class='{active: isActive("/login")}')
-          a(href='/login') Login
+        li(ng-hide='isLoggedIn()', <% if(filters.uirouter) { %>ui-sref-active='active'<% } else { %>ng-class='{active: isActive("/login")}'<% } %>)
+          a(<% if(filters.uirouter) { %>ui-sref='login'<% } else { %>href='/login'<% } %>) Login
 
         li(ng-show='isLoggedIn()')
           p.navbar-text Hello {{ getCurrentUser().name }}
 
-        li(ng-show='isLoggedIn()', ng-class='{active: isActive("/settings")}')
-          a(href='/settings')
+        li(ng-show='isLoggedIn()', <% if(filters.uirouter) { %>ui-sref-active='active'<% } else { %>ng-class='{active: isActive("/settings")}'<% } %>)
+          a(<% if(filters.uirouter) { %>ui-sref='settings'<% } else { %>href='/settings'<% } %>)
             span.glyphicon.glyphicon-cog
 
-        li(ng-show='isLoggedIn()', ng-class='{active: isActive("/logout")}')
+        li(ng-show='isLoggedIn()')
           a(href='', ng-click='logout()') Logout<% } %>

--- a/app/templates/client/components/navbar/navbar.controller(coffee).coffee
+++ b/app/templates/client/components/navbar/navbar.controller(coffee).coffee
@@ -4,7 +4,7 @@ angular.module '<%= scriptAppName %>'
 .controller 'NavbarCtrl', ($scope, $location<% if(filters.auth) {%>, Auth<% } %>) ->
   $scope.menu = [
     title: 'Home'
-    link: '/'
+    <% if(filters.uirouter) { %>state: 'main'<% } else { %>link: '/'<% } %>
   ]
   $scope.isCollapsed = true<% if(filters.auth) {%>
   $scope.isLoggedIn = Auth.isLoggedIn
@@ -13,7 +13,7 @@ angular.module '<%= scriptAppName %>'
 
   $scope.logout = ->
     Auth.logout()
-    $location.path '/login'<% } %>
+    $location.path '/login'<% } %><% if(!filters.uirouter) { %>
 
   $scope.isActive = (route) ->
-    route is $location.path()
+    route is $location.path()<% } %>

--- a/app/templates/client/components/navbar/navbar.controller(js).js
+++ b/app/templates/client/components/navbar/navbar.controller(js).js
@@ -4,7 +4,7 @@ angular.module('<%= scriptAppName %>')
   .controller('NavbarCtrl', function ($scope, $location<% if(filters.auth) {%>, Auth<% } %>) {
     $scope.menu = [{
       'title': 'Home',
-      'link': '/'
+      <% if(filters.uirouter) { %>'state': 'main'<% } else { %>'link': '/'<% } %>
     }];
 
     $scope.isCollapsed = true;<% if(filters.auth) {%>
@@ -15,9 +15,9 @@ angular.module('<%= scriptAppName %>')
     $scope.logout = function() {
       Auth.logout();
       $location.path('/login');
-    };<% } %>
+    };<% } %><% if(!filters.uirouter) { %>
 
     $scope.isActive = function(route) {
       return route === $location.path();
-    };
+    };<% } %>
   });


### PR DESCRIPTION
Changes:
- Use `ui-sref` instead of `href` or `ng-href` when ui-router is chosen
- Use `ui-sref-active` instead of `ng-class='{active: isActive()}'` when ui-router is chosen
- Use `$scope.menu[n].state` instead of `$scope.menu[n].link` when ui-router is chosen (attempt to remove possible confusion)
- Omit `$scope.isActive` when ui-router is chosen
- Simplify `navbar(jade).jade` templating (remove extra `<% if (filters.auth) %>` tag)

closes #436, #331
