### PR TITLE
feat(app:socket.io): build socket.io into vendor.js

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -25,7 +25,8 @@
     "passport-google-oauth": "latest",<% } %>
     "composable-middleware": "^0.3.0",
     "connect-mongo": "^0.4.1"<% if(filters.socketio) { %>,
-    "socket.io": "~1.0.6",
+    "socket.io": "^1.0.6",
+    "socket.io-client": "^1.0.6",
     "socketio-jwt": "^2.0.2"<% } %>
   },
   "devDependencies": {

--- a/app/templates/client/components/socket(socketio)/socket.service(coffee).coffee
+++ b/app/templates/client/components/socket(socketio)/socket.service(coffee).coffee
@@ -7,9 +7,9 @@ angular.module '<%= scriptAppName %>'
 
   # socket.io now auto-configures its connection when we omit a connection url
   ioSocket = io '',
-    'reconnection limit': 10 * 1000
     # Send auth token on connection, you will need to DI the Auth service above
     # 'query': 'token=' + Auth.getToken()
+    path: '/socket.io-client'
 
   socket = socketFactory ioSocket: ioSocket
 

--- a/app/templates/client/components/socket(socketio)/socket.service.js
+++ b/app/templates/client/components/socket(socketio)/socket.service.js
@@ -8,6 +8,7 @@ angular.module('<%= scriptAppName %>')
     var ioSocket = io('', {
       // Send auth token on connection, you will need to DI the Auth service above
       // 'query': 'token=' + Auth.getToken()
+      path: '/socket.io-client'
     });
 
     var socket = socketFactory({

--- a/app/templates/client/index.html
+++ b/app/templates/client/index.html
@@ -44,10 +44,10 @@
     <script src="bower_components/es5-shim/es5-shim.js"></script>
     <script src="bower_components/json3/lib/json3.min.js"></script>
     <![endif]-->
-<% if(filters.socketio) { %>    <script src="socket.io/socket.io.js"></script><% } %>
-    <!-- build:js(client) app/vendor.js -->
+    <!-- build:js({client<% if(filters.socketio) { %>,node_modules<% } %>}) app/vendor.js -->
       <!-- bower:js -->
       <!-- endbower -->
+      <% if(filters.socketio) { %><script src="socket.io-client/socket.io.js"></script><% } %>
     <!-- endbuild -->
 
         <!-- build:js({.tmp,client}) app/app.js -->

--- a/app/templates/server/app.js
+++ b/app/templates/server/app.js
@@ -20,7 +20,10 @@ if(config.seedDB) { require('./config/seed'); }
 <% } %>// Setup server
 var app = express();
 var server = require('http').createServer(app);<% if (filters.socketio) { %>
-var socketio = require('socket.io').listen(server);
+var socketio = require('socket.io')(server, {
+  serveClient: (config.env === 'production') ? false : true,
+  path: '/socket.io-client'
+});
 require('./config/socketio')(socketio);<% } %>
 require('./config/express')(app);
 require('./routes')(app);


### PR DESCRIPTION
Changes:
- Move socket.io script tag inside vendor.js build
- Add `node_modules/socket.io/node_modules` to vendor script locations
- Change socket.io path to `/socket.io-client` in serve and client
- Will not serve socket.io.js when server is ran in `production` env
