### PR TITLE
refactor(serve:favicon) change favicon package

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -7,7 +7,7 @@
     "morgan": "~1.0.0",
     "body-parser": "~1.5.0",
     "method-override": "~1.0.0",
-    "static-favicon": "~1.0.1",
+    "serve-favicon": "^2.0.1",
     "cookie-parser": "~1.0.1",
     "express-session": "~1.0.2",
     "errorhandler": "~1.0.0",

--- a/app/templates/server/config/express.js
+++ b/app/templates/server/config/express.js
@@ -5,7 +5,7 @@
 'use strict';
 
 var express = require('express');
-var favicon = require('static-favicon');
+var favicon = require('serve-favicon');
 var morgan = require('morgan');
 var compression = require('compression');
 var bodyParser = require('body-parser');

--- a/test/fixtures/.bowerrc
+++ b/test/fixtures/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory": "bower_components"
+}

--- a/test/fixtures/package.json
+++ b/test/fixtures/package.json
@@ -5,7 +5,7 @@
     "morgan": "~1.0.0",
     "body-parser": "~1.5.0",
     "method-override": "~1.0.0",
-    "static-favicon": "~1.0.1",
+    "serve-favicon": "^2.0.1",
     "cookie-parser": "~1.0.1",
     "express-session": "~1.0.2",
     "errorhandler": "~1.0.0",


### PR DESCRIPTION
change static-favicon to serve-favicon because the npm install process
recommend to change it.

npm WARN deprecated static-favicon@1.0.2: use serve-favicon module
