### PR TITLE
fix(app-config): Use parentheses to fix string concat in config

### DIFF
--- a/app/templates/server/config/environment/index.js
+++ b/app/templates/server/config/environment/index.js
@@ -44,19 +44,19 @@ var all = {
   facebook: {
     clientID:     process.env.FACEBOOK_ID || 'id',
     clientSecret: process.env.FACEBOOK_SECRET || 'secret',
-    callbackURL:  process.env.DOMAIN || '' + '/auth/facebook/callback'
+    callbackURL:  (process.env.DOMAIN || '') + '/auth/facebook/callback'
   },
 <% } if(filters.twitterAuth) { %>
   twitter: {
     consumerKey:     process.env.TWITTER_ID || 'id',
     consumerSecret: process.env.TWITTER_SECRET || 'secret',
-    callbackURL:  process.env.DOMAIN || '' + '/auth/twitter/callback'
+    callbackURL:  (process.env.DOMAIN || '') + '/auth/twitter/callback'
   },
 <% } if(filters.googleAuth) { %>
   google: {
     clientID:     process.env.GOOGLE_ID || 'id',
     clientSecret: process.env.GOOGLE_SECRET || 'secret',
-    callbackURL:  process.env.DOMAIN || '' + '/auth/google/callback'
+    callbackURL:  (process.env.DOMAIN || '') + '/auth/google/callback'
   }<% } %>
 };
 


### PR DESCRIPTION
Changes:
- wrap `process.env.DOMAIN || ''` in parentheses to correct the order of the OR operator and string concat

Closes #466
