### PR TITLE
feat(auth): implement bcrypt and make async for performance

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "main": "server/app.js",
   "dependencies": {
+    "bcrypt": "~0.8.0",
     "express": "~4.0.0",
     "morgan": "~1.0.0",
     "body-parser": "~1.5.0",

--- a/app/templates/server/api/user(auth)/user.controller.js
+++ b/app/templates/server/api/user(auth)/user.controller.js
@@ -14,7 +14,7 @@ var validationError = function(res, err) {
  * restriction: 'admin'
  */
 exports.index = function(req, res) {
-  User.find({}, '-salt -hashedPassword', function (err, users) {
+  User.find({}, '-salt -password', function (err, users) {
     if(err) return res.send(500, err);
     res.json(200, users);
   });
@@ -67,15 +67,19 @@ exports.changePassword = function(req, res, next) {
   var newPass = String(req.body.newPassword);
 
   User.findById(userId, function (err, user) {
-    if(user.authenticate(oldPass)) {
-      user.password = newPass;
-      user.save(function(err) {
-        if (err) return validationError(res, err);
-        res.send(200);
-      });
-    } else {
-      res.send(403);
-    }
+    user.authenticate(oldPass, function(authErr, authenticated) {
+      if (authErr) res.send(403);
+
+      if (authenticated) {
+        user.password = newPass;
+        user.save(function(err) {
+          if (err) return validationError(res, err);
+          res.send(200);
+        });
+      } else {
+        res.send(403);
+      }
+    });
   });
 };
 
@@ -86,7 +90,7 @@ exports.me = function(req, res, next) {
   var userId = req.user._id;
   User.findOne({
     _id: userId
-  }, '-salt -hashedPassword', function(err, user) { // don't ever give out the password or salt
+  }, '-salt -password', function(err, user) { // don't ever give out the password or salt
     if (err) return next(err);
     if (!user) return res.json(404);
     res.json(user);

--- a/app/templates/server/auth(auth)/local/passport.js
+++ b/app/templates/server/auth(auth)/local/passport.js
@@ -15,10 +15,14 @@ exports.setup = function (User, config) {
         if (!user) {
           return done(null, false, { message: 'This email is not registered.' });
         }
-        if (!user.authenticate(password)) {
-          return done(null, false, { message: 'This password is not correct.' });
-        }
-        return done(null, user);
+        user.authenticate(password, function(authError, authenticated) {
+          if (authError) return done(authError);
+          if (!authenticated) {
+            return done(null, false, { message: 'This password is not correct.' });
+          } else {
+            return done(null, user);
+          }
+        });
       });
     }
   ));


### PR DESCRIPTION
- Implement bcrypt for better security
- Update to be async
- Update tests and add new test for changed password
- User.authenticate() User.makeSalt() and User.encryptPassword() public API remains same
- User.authenticate() User.makeSalt() and User.encryptPassword() callbacks are optional
- User.makeSalt() can take an option rounds to increase salt iterations
- Change User schema from hashedPassword to password
- #474
