### PR TITLE
feat(auth): make crypto async

### DIFF
--- a/app/templates/server/.jshintrc
+++ b/app/templates/server/.jshintrc
@@ -1,4 +1,5 @@
 {
+  "expr": true,
   "node": true,
   "esnext": true,
   "bitwise": true,

--- a/app/templates/server/api/user(auth)/user.model.js
+++ b/app/templates/server/api/user(auth)/user.model.js
@@ -12,7 +12,7 @@ var UserSchema = new Schema({
     type: String,
     default: 'user'
   },
-  hashedPassword: String,
+  password: String,
   provider: String,
   salt: String<% if (filters.oauth) { %>,<% if (filters.facebookAuth) { %>
   facebook: {},<% } %><% if (filters.twitterAuth) { %>
@@ -24,16 +24,6 @@ var UserSchema = new Schema({
 /**
  * Virtuals
  */
-UserSchema
-  .virtual('password')
-  .set(function(password) {
-    this._password = password;
-    this.salt = this.makeSalt();
-    this.hashedPassword = this.encryptPassword(password);
-  })
-  .get(function() {
-    return this._password;
-  });
 
 // Public profile information
 UserSchema
@@ -69,10 +59,10 @@ UserSchema
 
 // Validate empty password
 UserSchema
-  .path('hashedPassword')
-  .validate(function(hashedPassword) {<% if (filters.oauth) { %>
+  .path('password')
+  .validate(function(password) {<% if (filters.oauth) { %>
     if (authTypes.indexOf(this.provider) !== -1) return true;<% } %>
-    return hashedPassword.length;
+    return password.length;
   }, 'Password cannot be blank');
 
 // Validate email is not taken
@@ -99,12 +89,26 @@ var validatePresenceOf = function(value) {
  */
 UserSchema
   .pre('save', function(next) {
-    if (!this.isNew) return next();
+    // Handle new/update passwords
+    if (this.password) {
+      if (!validatePresenceOf(this.password)<% if (filters.oauth) { %> && authTypes.indexOf(this.provider) === -1<% } %>)
+        next(new Error('Invalid password'));
 
-    if (!validatePresenceOf(this.hashedPassword)<% if (filters.oauth) { %> && authTypes.indexOf(this.provider) === -1<% } %>)
-      next(new Error('Invalid password'));
-    else
+      // Make salt with a callback
+      var _this = this;
+      this.makeSalt(function(saltErr, salt) {
+        if (saltErr) next(saltErr);
+        _this.salt = salt;
+        // Async hash
+        _this.encryptPassword(_this.password, function(encryptErr, hashedPassword) {
+          if (encryptErr) next(encryptErr);
+          _this.password = hashedPassword;
+          next();
+        });
+      });
+    } else {
       next();
+    }
   });
 
 /**
@@ -115,34 +119,82 @@ UserSchema.methods = {
    * Authenticate - check if the passwords are the same
    *
    * @param {String} plainText
+   * @callback {callback} Optional callback
    * @return {Boolean}
    * @api public
    */
-  authenticate: function(plainText) {
-    return this.encryptPassword(plainText) === this.hashedPassword;
+  authenticate: function(password, callback) {
+    if (!callback)
+      return this.password === this.encryptPassword(password);
+
+    var _this = this;
+    this.encryptPassword(password, function(err, pwdGen) {
+      if (err) callback(err);
+
+      if (_this.password === pwdGen) {
+        callback(null, true);
+      } else {
+        callback(null, false);
+      }
+    });
   },
 
   /**
    * Make salt
    *
+   * @param {Number} byteSize Optional salt byte size, default to 16
+   * @callback {callback} Optional callback
    * @return {String}
    * @api public
    */
-  makeSalt: function() {
-    return crypto.randomBytes(16).toString('base64');
+  makeSalt: function(byteSize, callback) {
+    var defaultByteSize = 16;
+
+    if (typeof arguments[0] === 'function') {
+      callback = arguments[0];
+      byteSize = defaultByteSize;
+    } else if (typeof arguments[1] === 'function') {
+      callback = arguments[1];
+    }
+
+    if (!byteSize) {
+      byteSize = defaultByteSize;
+    }
+
+    if (!callback) {
+      return crypto.randomBytes(byteSize).toString('base64');
+    }
+
+    return crypto.randomBytes(byteSize, function(err, salt) {
+      if (err) callback(err);
+      return callback(null, salt.toString('base64'));
+    });
   },
 
   /**
    * Encrypt password
    *
    * @param {String} password
+   * @callback {callback} Optional callback
    * @return {String}
    * @api public
    */
-  encryptPassword: function(password) {
-    if (!password || !this.salt) return '';
+  encryptPassword: function(password, callback) {
+    if (!password || !this.salt) {
+      return null;
+    }
+
+    var defaultIterations = 10000;
+    var defaultKeyLength = 64;
     var salt = new Buffer(this.salt, 'base64');
-    return crypto.pbkdf2Sync(password, salt, 10000, 64).toString('base64');
+
+    if (!callback)
+      return crypto.pbkdf2Sync(password, salt, defaultIterations, defaultKeyLength).toString('base64');
+
+    return crypto.pbkdf2(password, salt, defaultIterations, defaultKeyLength, function(err, key) {
+      if (err) callback(err);
+      return callback(null, key.toString('base64'));
+    });
   }
 };
 

--- a/app/templates/server/auth(auth)/local/passport.js
+++ b/app/templates/server/auth(auth)/local/passport.js
@@ -15,10 +15,14 @@ exports.setup = function (User, config) {
         if (!user) {
           return done(null, false, { message: 'This email is not registered.' });
         }
-        if (!user.authenticate(password)) {
-          return done(null, false, { message: 'This password is not correct.' });
-        }
-        return done(null, user);
+        user.authenticate(password, function(authError, authenticated) {
+          if (authError) return done(authError);
+          if (!authenticated) {
+            return done(null, false, { message: 'This password is not correct.' });
+          } else {
+            return done(null, user);
+          }
+        });
       });
     }
   ));


### PR DESCRIPTION
- Update tests and add new test for changed password
- User.authenticate() User.makeSalt() and User.encryptPassword() public API remains same
- User.authenticate() User.makeSalt() and User.encryptPassword() callbacks are optional
- Change User schema from hashedPassword to password
- Remove unnecessary virtual attribute User.password, getters and setters are not async
- #474
- #479 
