### PR TITLE
refactor(server-tests): use sinon-chai and `mocha.conf.js`

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -486,7 +486,8 @@ module.exports = function (grunt) {
 
     mochaTest: {
       options: {
-        reporter: 'spec'
+        reporter: 'spec',
+        require: 'mocha.conf.js'
       },
       src: ['server/**/*.spec.js']
     },

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -30,6 +30,7 @@
     "socketio-jwt": "^2.0.2"<% } %>
   },
   "devDependencies": {
+    "chai-as-promised": "^4.1.1",
     "grunt": "~0.4.4",
     "grunt-autoprefixer": "~0.7.2",
     "grunt-wiredep": "~1.8.0",
@@ -86,7 +87,7 @@
     "karma": "~0.12.9",
     "karma-ng-html2js-preprocessor": "~0.1.0",
     "supertest": "~0.11.0",
-    "should": "~3.3.1"
+    "sinon-chai": "^2.5.0"
   },
   "engines": {
     "node": ">=0.10.0"

--- a/app/templates/mocha.conf.js
+++ b/app/templates/mocha.conf.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var chai = require('chai');
+var sinon = require('sinon');
+var sinonChai = require('sinon-chai');
+var chaiAsPromised = require('chai-as-promised');
+
+global.expect = chai.expect;
+global.assert = chai.assert;
+chai.should();
+chai.use(sinonChai);
+chai.use(chaiAsPromised);

--- a/app/templates/server/api/thing/thing.spec.js
+++ b/app/templates/server/api/thing/thing.spec.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var should = require('should');
 var app = require('../../app');
 var request = require('supertest');
 
@@ -13,7 +12,7 @@ describe('GET /api/things', function() {
       .expect('Content-Type', /json/)
       .end(function(err, res) {
         if (err) return done(err);
-        res.body.should.be.instanceof(Array);
+        res.body.should.be.instanceOf(Array);
         done();
       });
   });

--- a/app/templates/server/api/user(auth)/user.model.spec.js
+++ b/app/templates/server/api/user(auth)/user.model.spec.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var should = require('should');
 var app = require('../../app');
 var User = require('./user.model');
 
@@ -12,17 +11,14 @@ var user = new User({
 });
 
 describe('User Model', function() {
-  before(function(done) {
-    // Clear users before testing
-    User.remove().exec().then(function() {
-      done();
-    });
+
+  // Clear users before testing
+  before(function() {
+    return User.remove().exec();
   });
 
-  afterEach(function(done) {
-    User.remove().exec().then(function() {
-      done();
-    });
+  afterEach(function() {
+    return User.remove().exec();
   });
 
   it('should begin with no users', function(done) {
@@ -36,7 +32,7 @@ describe('User Model', function() {
     user.save(function() {
       var userDup = new User(user);
       userDup.save(function(err) {
-        should.exist(err);
+        err.should.be.instanceOf(Error);
         done();
       });
     });
@@ -45,7 +41,7 @@ describe('User Model', function() {
   it('should fail when saving without an email', function(done) {
     user.email = '';
     user.save(function(err) {
-      should.exist(err);
+      err.should.be.instanceOf(Error);
       done();
     });
   });

--- a/endpoint/templates/name.spec.js
+++ b/endpoint/templates/name.spec.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var should = require('should');
 var app = require('../../app');
 var request = require('supertest');
 
@@ -13,7 +12,7 @@ describe('GET <%= route %>', function() {
       .expect('Content-Type', /json/)
       .end(function(err, res) {
         if (err) return done(err);
-        res.body.should.be.instanceof(Array);
+        res.body.should.be.instanceOf(Array);
         done();
       });
   });

--- a/test/fixtures/package.json
+++ b/test/fixtures/package.json
@@ -30,6 +30,7 @@
     "socketio-jwt": "^2.0.2"
   },
   "devDependencies": {
+    "chai-as-promised": "^4.1.1",
     "grunt": "~0.4.4",
     "grunt-autoprefixer": "~0.7.2",
     "grunt-wiredep": "~1.8.0",
@@ -86,7 +87,7 @@
     "karma": "~0.12.9",
     "karma-ng-html2js-preprocessor": "~0.1.0",
     "supertest": "~0.11.0",
-    "should": "~3.3.1"
+    "sinon-chai": "^2.5.0"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
Changes:
- add `mocha.conf.js` and use it as a `require` in `mochaTest` task
- switch `should.js` for `mocha-chai`
- change server-side test assertions to user chai assertions

Breaking Changes:
- should.js is no longer included, chai assertions should be used instead.
