### PR TITLE
Grunt task for deploying application

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -31,7 +31,12 @@ module.exports = function (grunt) {
     yeoman: {
       // configurable paths
       client: require('./bower.json').appPath || 'client',
-      deploy_path: '/var/www',
+      deploy: {
+        hostname : 'root',
+        username : 'example.com',
+        password : '',
+        path : '/var/www'
+      },
       dist: 'dist'
     },
     express: {
@@ -715,12 +720,13 @@ module.exports = function (grunt) {
         live: {
           options: {
             servers: [{
-              host: 'example.com',
-              username: 'password',
+              host: '<%%= yeoman.deploy.hostname %>',
+              username: '<%%= yeoman.deploy.username %>',
+              password: '<%%= yeoman.deploy.password %>'
             }],
             execute : {
               before: [
-                'rm -rf <%%= yeoman.deploy_path %>/current/node_modules',
+                'rm -rf <%%= yeoman.deploy.path %>/current/node_modules',
               ],
               after: [
                 //create logs folder
@@ -732,11 +738,11 @@ module.exports = function (grunt) {
                 //start application
                 'forever -m 100 -a -e @current/logs/err.log -l @current/logs/logs.log start @current/server/app.js',
                 //log this release
-                'echo "Verstion \"@version\" deployed at `date`" >> <%%= yeoman.deploy_path %>/deploy.log'
+                'echo "Verstion \"@version\" deployed at `date`" >> <%%= yeoman.deploy.path %>/deploy.log'
               ],
             },
             source: process.cwd() + '/dist/*',
-            dest: '<%%= yeoman.deploy_path %>'
+            dest: '<%%= yeoman.deploy.path %>'
           }
         }
       },

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -761,7 +761,7 @@ module.exports = function (grunt) {
           'newer:jshint',
           'test',
           'build',
-          'up:live',
+          'up:live'
       ]);
     }
 
@@ -769,9 +769,9 @@ module.exports = function (grunt) {
       return grunt.task.run([
           'newer:jshint',
           'test',
-          'build'
+          'build',
           'shell::versionmajor',
-          'up:live',
+          'up:live'
       ]);
     }
 
@@ -779,9 +779,9 @@ module.exports = function (grunt) {
       return grunt.task.run([
           'newer:jshint',
           'test',
-          'build'
+          'build',
           'shell::versionminor',
-          'up:live',
+          'up:live'
       ]);
     }
 
@@ -789,9 +789,9 @@ module.exports = function (grunt) {
       return grunt.task.run([
           'newer:jshint',
           'test',
-          'build'
+          'build',
           'shell::versionpatch',
-          'up:live',
+          'up:live'
       ]);
     }
 

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -749,7 +749,6 @@ module.exports = function (grunt) {
 
     },
   });
-
   
   grunt.registerTask('deploy', function( mode ){
 
@@ -759,7 +758,8 @@ module.exports = function (grunt) {
 
     if( mode == 'noupdate') {
       return grunt.task.run([
-          'default',
+          'newer:jshint',
+          'test',
           'build',
           'up:live',
       ]);
@@ -767,27 +767,30 @@ module.exports = function (grunt) {
 
     if( mode == 'major') {
       return grunt.task.run([
-          'default',
+          'newer:jshint',
+          'test',
+          'build'
           'shell::versionmajor',
-          'build',
           'up:live',
       ]);
     }
 
     if( mode == 'minor' ) {
       return grunt.task.run([
-          'default',
+          'newer:jshint',
+          'test',
+          'build'
           'shell::versionminor',
-          'build',
           'up:live',
       ]);
     }
 
     if( mode == 'patch' ) {
       return grunt.task.run([
-          'default',
+          'newer:jshint',
+          'test',
+          'build'
           'shell::versionpatch',
-          'build',
           'up:live',
       ]);
     }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "grunt-conventional-changelog": "~1.0.0",
     "grunt-mocha-test": "^0.11.0",
     "grunt-release": "~0.6.0",
+    "grunt-up": "^1.0.6",
+    "grunt-shell": "^1.1.1",
     "load-grunt-tasks": "~0.2.0",
     "marked": "~0.2.8",
     "mocha": "~1.21.0",


### PR DESCRIPTION
I think from this fullstack generator missing a deploy part. So i created a simple deploying task that increase the package version using patch, minor or major release and upload the dist contents to the server after build task

Available grunt tasks:
- ```grunt deploy:patch``` ( 1.0.0 to 1.0.1 )
- ```grunt deploy:minor``` ( 1.0.0 to 1.1.0 )
- ```grunt deploy:major``` ( 1.0.0 to 2.0.0 )
- ```grunt deploy:noupdate``` ( Will not increment version )

Executing each of this commands will trigger following commands: **newer:jshint**, **test**, **build** and [**up:live**][grunt-up]. On the server, in the deploy path will have the following structure ( having /var/www as deploy path ):

- /var/www/releases/vX.X.X
- /var/www/current ( pointing to current release from releases directory )

After creating symbolic link to the new release the [forever][forever] will be executed to start/restart the application ( server/app.js )

I use this for my application and maybe this will be usefully for others. 

What do you think about this?

[forever]:https://github.com/nodejitsu/forever
[grunt-up]:https://www.npmjs.org/package/grunt-up