### PR TITLE
Don't add authorization to http request for 3rd party service

### DIFF
--- a/app/templates/client/app/app(js).js
+++ b/app/templates/client/app/app(js).js
@@ -22,7 +22,7 @@ angular.module('<%= scriptAppName %>', [<%= angularModules %>])
       // Add authorization token to headers
       request: function (config) {
         config.headers = config.headers || {};
-        if ($cookieStore.get('token')) {
+        if ($cookieStore.get('token') && config.url.indexOf('http')<0) {
           config.headers.Authorization = 'Bearer ' + $cookieStore.get('token');
         }
         return config;


### PR DESCRIPTION
For example, REST request to https://www.googleapis.com/youtube/v3/ should not contain user token, and if it should include it is not this token.

Question: maybe a better way to identify the request is not to the local server?
