### PR TITLE
fix(deps): use angular ~1.2 before migrated to 1.3

### DIFF
--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -2,15 +2,15 @@
   "name": "<%= _.slugify(_.humanize(appname)) %>",
   "version": "0.0.0",
   "dependencies": {
-    "angular": ">=1.2.*",
+    "angular": "~1.2",
     "json3": "~3.3.1",
     "es5-shim": "~3.0.1",<% if(filters.bootstrap) { %><% if (filters.sass) { %>
     "bootstrap-sass-official": "~3.1.1",<% } %>
     "bootstrap": "~3.1.1",<% } %>
-    "angular-resource": ">=1.2.*",
-    "angular-cookies": ">=1.2.*",
-    "angular-sanitize": ">=1.2.*",<% if (filters.ngroute) { %>
-    "angular-route": ">=1.2.*",<% } %><% if (filters.uibootstrap) { %>
+    "angular-resource": "~1.2",
+    "angular-cookies": "~1.2",
+    "angular-sanitize": "~1.2",<% if (filters.ngroute) { %>
+    "angular-route": "~1.2",<% } %><% if (filters.uibootstrap) { %>
     "angular-bootstrap": "~0.11.0",<% } %>
     "font-awesome": ">=4.1.0",
     "lodash": "~2.4.1"<% if (filters.socketio) { %>,
@@ -18,7 +18,7 @@
     "angular-ui-router": "~0.2.10"<% } %>
   },
   "devDependencies": {
-    "angular-mocks": ">=1.2.*",
-    "angular-scenario": ">=1.2.*"
+    "angular-mocks": "~1.2",
+    "angular-scenario": "~1.2"
   }
 }

--- a/test/test-file-creation.js
+++ b/test/test-file-creation.js
@@ -314,6 +314,41 @@ describe('angular-fullstack generator', function () {
     }.bind(this));
   });
 
+  describe('making sure test fixtures are present', function() {
+
+    it('should have package.json in fixtures', function() {
+      helpers.assertFile([
+        path.join(__dirname, 'fixtures', 'package.json')
+      ]);
+    });
+
+    it('should have bower.json in fixtures', function() {
+      helpers.assertFile([
+        path.join(__dirname, 'fixtures', 'bower.json')
+      ]);
+    });
+
+    it('should have all npm packages in fixtures/node_modules', function() {
+      var packageJson = require('./fixtures/package.json');
+      var deps = Object.keys(packageJson.dependencies);
+      deps = deps.concat(Object.keys(packageJson.devDependencies));
+      deps = deps.map(function(dep) {
+        return path.join(__dirname, 'fixtures', 'node_modules', dep);
+      });
+      helpers.assertFile(deps);
+    });
+
+    it('should have all bower packages in fixtures/bower_components', function() {
+      var bowerJson = require('./fixtures/bower.json');
+      var deps = Object.keys(bowerJson.dependencies);
+      deps = deps.concat(Object.keys(bowerJson.devDependencies));
+      deps = deps.map(function(dep) {
+        return path.join(__dirname, 'fixtures', 'bower_components', dep);
+      });
+      helpers.assertFile(deps);
+    });
+  });
+
   describe('running app', function() {
 
     beforeEach(function() {


### PR DESCRIPTION
Change angular version spec from ">=1.2.*" to "~1.2" to ensure generator
tests run before migration to 1.3 is completed.

Closes #654
