### PR TITLE
Minor fixes

### DIFF
--- a/app/templates/server/api/thing/thing.controller.js
+++ b/app/templates/server/api/thing/thing.controller.js
@@ -37,7 +37,7 @@ exports.index = function(req, res) {<% if (!filters.mongoose) { %>
   ]);<% } %><% if (filters.mongoose) { %>
   Thing.find(function (err, things) {
     if(err) { return handleError(res, err); }
-    return res.json(200, things);
+    return res.status(200).json(things);
   });<% } %>
 };<% if (filters.mongoose) { %>
 
@@ -45,7 +45,7 @@ exports.index = function(req, res) {<% if (!filters.mongoose) { %>
 exports.show = function(req, res) {
   Thing.findById(req.params.id, function (err, thing) {
     if(err) { return handleError(res, err); }
-    if(!thing) { return res.send(404); }
+    if(!thing) { return res.status(404).end(); }
     return res.json(thing);
   });
 };
@@ -54,7 +54,7 @@ exports.show = function(req, res) {
 exports.create = function(req, res) {
   Thing.create(req.body, function(err, thing) {
     if(err) { return handleError(res, err); }
-    return res.json(201, thing);
+    return res.status(201).json(thing);
   });
 };
 
@@ -63,11 +63,11 @@ exports.update = function(req, res) {
   if(req.body._id) { delete req.body._id; }
   Thing.findById(req.params.id, function (err, thing) {
     if (err) { return handleError(res, err); }
-    if(!thing) { return res.send(404); }
+    if(!thing) { return res.status(404).end(); }
     var updated = _.merge(thing, req.body);
     updated.save(function (err) {
       if (err) { return handleError(res, err); }
-      return res.json(200, thing);
+      return res.status(200).json(thing);
     });
   });
 };
@@ -76,14 +76,14 @@ exports.update = function(req, res) {
 exports.destroy = function(req, res) {
   Thing.findById(req.params.id, function (err, thing) {
     if(err) { return handleError(res, err); }
-    if(!thing) { return res.send(404); }
+    if(!thing) { return res.status(404).end(); }
     thing.remove(function(err) {
       if(err) { return handleError(res, err); }
-      return res.send(204);
+      return res.status(204).end();
     });
   });
 };
 
 function handleError(res, err) {
-  return res.send(500, err);
+  return res.status(500).json(err);
 }<% } %>

--- a/app/templates/server/auth(auth)/auth.service.js
+++ b/app/templates/server/auth(auth)/auth.service.js
@@ -27,7 +27,7 @@ function isAuthenticated() {
     .use(function(req, res, next) {
       User.findById(req.user._id, function (err, user) {
         if (err) return next(err);
-        if (!user) return res.send(401);
+        if (!user) return res.status(401).end();
 
         req.user = user;
         next();
@@ -48,7 +48,7 @@ function hasRole(roleRequired) {
         next();
       }
       else {
-        res.send(403);
+        res.status(403).end();
       }
     });
 }

--- a/app/templates/server/components/errors/index.js
+++ b/app/templates/server/components/errors/index.js
@@ -13,7 +13,7 @@ module.exports[404] = function pageNotFound(req, res) {
 
   res.status(result.status);
   res.render(viewFilePath, function (err) {
-    if (err) { return res.json(result, result.status); }
+    if (err) { return res.status(result.status).json(result); }
 
     res.render(viewFilePath);
   });

--- a/test/fixtures/package.json
+++ b/test/fixtures/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "main": "server/app.js",
   "dependencies": {
-    "express": "~4.0.0",
+    "express": "~4.9.0",
     "morgan": "~1.0.0",
     "body-parser": "~1.5.0",
     "method-override": "~1.0.0",


### PR DESCRIPTION
- Response in express of the form "res.send(status, message)" has been deprecated. Updated responses to use the updated format of "res.status(xxx).json(object)" or "res.status(xxx).end()"
- Fix: If the :id attribute in the API does not evaluate to a valid mongoose ObjectID, it produces a Cast error.
- Removed some unnecessary dependency injections where they were not being used.
