### PR TITLE
refactor: deprecate res.[send|json](status)

### DIFF
--- a/app/templates/server/api/thing/thing.controller.js
+++ b/app/templates/server/api/thing/thing.controller.js
@@ -37,7 +37,7 @@ exports.index = function(req, res) {<% if (!filters.mongoose) { %>
   ]);<% } %><% if (filters.mongoose) { %>
   Thing.find(function (err, things) {
     if(err) { return handleError(res, err); }
-    return res.json(200, things);
+    return res.status(200).json(things);
   });<% } %>
 };<% if (filters.mongoose) { %>
 
@@ -45,7 +45,7 @@ exports.index = function(req, res) {<% if (!filters.mongoose) { %>
 exports.show = function(req, res) {
   Thing.findById(req.params.id, function (err, thing) {
     if(err) { return handleError(res, err); }
-    if(!thing) { return res.send(404); }
+    if(!thing) { return res.status(404).send('Not Found'); }
     return res.json(thing);
   });
 };
@@ -54,7 +54,7 @@ exports.show = function(req, res) {
 exports.create = function(req, res) {
   Thing.create(req.body, function(err, thing) {
     if(err) { return handleError(res, err); }
-    return res.json(201, thing);
+    return res.status(201).json(thing);
   });
 };
 
@@ -63,11 +63,11 @@ exports.update = function(req, res) {
   if(req.body._id) { delete req.body._id; }
   Thing.findById(req.params.id, function (err, thing) {
     if (err) { return handleError(res, err); }
-    if(!thing) { return res.send(404); }
+    if(!thing) { return res.status(404).send('Not Found'); }
     var updated = _.merge(thing, req.body);
     updated.save(function (err) {
       if (err) { return handleError(res, err); }
-      return res.json(200, thing);
+      return res.status(200).json(thing);
     });
   });
 };
@@ -76,14 +76,14 @@ exports.update = function(req, res) {
 exports.destroy = function(req, res) {
   Thing.findById(req.params.id, function (err, thing) {
     if(err) { return handleError(res, err); }
-    if(!thing) { return res.send(404); }
+    if(!thing) { return res.status(404).send('Not Found'); }
     thing.remove(function(err) {
       if(err) { return handleError(res, err); }
-      return res.send(204);
+      return res.status(204).send('No Content');
     });
   });
 };
 
 function handleError(res, err) {
-  return res.send(500, err);
+  return res.status(500).send(err);
 }<% } %>

--- a/app/templates/server/api/user(auth)/user.controller.js
+++ b/app/templates/server/api/user(auth)/user.controller.js
@@ -6,7 +6,7 @@ var config = require('../../config/environment');
 var jwt = require('jsonwebtoken');
 
 var validationError = function(res, err) {
-  return res.json(422, err);
+  return res.status(422).json(err);
 };
 
 /**
@@ -15,8 +15,8 @@ var validationError = function(res, err) {
  */
 exports.index = function(req, res) {
   User.find({}, '-salt -hashedPassword', function (err, users) {
-    if(err) return res.send(500, err);
-    res.json(200, users);
+    if(err) return res.status(500).send(err);
+    res.status(200).json(users);
   });
 };
 
@@ -42,7 +42,7 @@ exports.show = function (req, res, next) {
 
   User.findById(userId, function (err, user) {
     if (err) return next(err);
-    if (!user) return res.send(401);
+    if (!user) return res.status(401).send('Unauthorized');
     res.json(user.profile);
   });
 };
@@ -53,8 +53,8 @@ exports.show = function (req, res, next) {
  */
 exports.destroy = function(req, res) {
   User.findByIdAndRemove(req.params.id, function(err, user) {
-    if(err) return res.send(500, err);
-    return res.send(204);
+    if(err) return res.status(500).send(err);
+    return res.status(204).send('No Content');
   });
 };
 
@@ -71,10 +71,10 @@ exports.changePassword = function(req, res, next) {
       user.password = newPass;
       user.save(function(err) {
         if (err) return validationError(res, err);
-        res.send(200);
+        res.status(200).send('OK');
       });
     } else {
-      res.send(403);
+      res.status(403).send('Forbidden');
     }
   });
 };
@@ -88,7 +88,7 @@ exports.me = function(req, res, next) {
     _id: userId
   }, '-salt -hashedPassword', function(err, user) { // don't ever give out the password or salt
     if (err) return next(err);
-    if (!user) return res.json(401);
+    if (!user) return res.status(401).send('Unauthorized');
     res.json(user);
   });
 };

--- a/app/templates/server/auth(auth)/auth.service.js
+++ b/app/templates/server/auth(auth)/auth.service.js
@@ -27,7 +27,7 @@ function isAuthenticated() {
     .use(function(req, res, next) {
       User.findById(req.user._id, function (err, user) {
         if (err) return next(err);
-        if (!user) return res.send(401);
+        if (!user) return res.status(401).send('Unauthorized');
 
         req.user = user;
         next();
@@ -48,7 +48,7 @@ function hasRole(roleRequired) {
         next();
       }
       else {
-        res.send(403);
+        res.status(403).send('Forbidden');
       }
     });
 }
@@ -64,7 +64,7 @@ function signToken(id) {
  * Set token cookie directly for oAuth strategies
  */
 function setTokenCookie(req, res) {
-  if (!req.user) return res.json(404, { message: 'Something went wrong, please try again.'});
+  if (!req.user) return res.status(404).json({ message: 'Something went wrong, please try again.'});
   var token = signToken(req.user._id, req.user.role);
   res.cookie('token', JSON.stringify(token));
   res.redirect('/');

--- a/app/templates/server/auth(auth)/local/index.js
+++ b/app/templates/server/auth(auth)/local/index.js
@@ -9,8 +9,8 @@ var router = express.Router();
 router.post('/', function(req, res, next) {
   passport.authenticate('local', function (err, user, info) {
     var error = err || info;
-    if (error) return res.json(401, error);
-    if (!user) return res.json(404, {message: 'Something went wrong, please try again.'});
+    if (error) return res.status(401).json(error);
+    if (!user) return res.status(404).json({message: 'Something went wrong, please try again.'});
 
     var token = auth.signToken(user._id, user.role);
     res.json({token: token});

--- a/endpoint/templates/name.controller.js
+++ b/endpoint/templates/name.controller.js
@@ -8,7 +8,7 @@ exports.index = function(req, res) {<% if (!filters.mongoose) { %>
   res.json([]);<% } %><% if (filters.mongoose) { %>
   <%= classedName %>.find(function (err, <%= name %>s) {
     if(err) { return handleError(res, err); }
-    return res.json(200, <%= name %>s);
+    return res.status(200).json(<%= name %>s);
   });<% } %>
 };<% if (filters.mongoose) { %>
 
@@ -16,7 +16,7 @@ exports.index = function(req, res) {<% if (!filters.mongoose) { %>
 exports.show = function(req, res) {
   <%= classedName %>.findById(req.params.id, function (err, <%= name %>) {
     if(err) { return handleError(res, err); }
-    if(!<%= name %>) { return res.send(404); }
+    if(!<%= name %>) { return res.status(404).send('Not Found'); }
     return res.json(<%= name %>);
   });
 };
@@ -25,7 +25,7 @@ exports.show = function(req, res) {
 exports.create = function(req, res) {
   <%= classedName %>.create(req.body, function(err, <%= name %>) {
     if(err) { return handleError(res, err); }
-    return res.json(201, <%= name %>);
+    return res.status(201).json(<%= name %>);
   });
 };
 
@@ -34,11 +34,11 @@ exports.update = function(req, res) {
   if(req.body._id) { delete req.body._id; }
   <%= classedName %>.findById(req.params.id, function (err, <%= name %>) {
     if (err) { return handleError(res, err); }
-    if(!<%= name %>) { return res.send(404); }
+    if(!<%= name %>) { return res.status(404).send('Not Found'); }
     var updated = _.merge(<%= name %>, req.body);
     updated.save(function (err) {
       if (err) { return handleError(res, err); }
-      return res.json(200, <%= name %>);
+      return res.status(200).json(<%= name %>);
     });
   });
 };
@@ -47,14 +47,14 @@ exports.update = function(req, res) {
 exports.destroy = function(req, res) {
   <%= classedName %>.findById(req.params.id, function (err, <%= name %>) {
     if(err) { return handleError(res, err); }
-    if(!<%= name %>) { return res.send(404); }
+    if(!<%= name %>) { return res.status(404).send('Not Found'); }
     <%= name %>.remove(function(err) {
       if(err) { return handleError(res, err); }
-      return res.send(204);
+      return res.status(204).send('No Content');
     });
   });
 };
 
 function handleError(res, err) {
-  return res.send(500, err);
+  return res.status(500).send(err);
 }<% } %>


### PR DESCRIPTION
res.send(status [, ...]) and res.json(status [, ...]) are now deprecated in Express
Occurrences of this have been refactored to res.status(status).[send|json](...)
