### PR TITLE
fix(openshift): fix processing of rhc app show output

### DIFF
--- a/openshift/index.js
+++ b/openshift/index.js
@@ -107,7 +107,7 @@ Generator.prototype.rhcAppShow = function rhcAppShow() {
       this.abort = true;
     }
     // No remote found
-    else if (stdout.search('not found.') < 0) {
+    else if (stdout.search('not found.') >= 0) {
       console.log('No existing app found.');
     }
     // Error


### PR DESCRIPTION
rhc returns the following text when application is not found 

``` bash
$ rhc app show test
Application 'test' not found.
```
