### PR TITLE
fix(gen): do not validate a user without email

### DIFF
--- a/app/templates/server/api/user(auth)/user.model.js
+++ b/app/templates/server/api/user(auth)/user.model.js
@@ -62,17 +62,19 @@ UserSchema
 // Validate empty email
 UserSchema
   .path('email')
+  .default(null) // hack to allow conditional requirement
   .validate(function(email) {<% if (filters.oauth) { %>
     if (authTypes.indexOf(this.provider) !== -1) return true;<% } %>
-    return email.length;
+    return (email instanceof String || typeof email === 'string') && email.length;
   }, 'Email cannot be blank');
 
 // Validate empty password
 UserSchema
   .path('hashedPassword')
+  .default(null) // hack to allow conditional requirement
   .validate(function(hashedPassword) {<% if (filters.oauth) { %>
     if (authTypes.indexOf(this.provider) !== -1) return true;<% } %>
-    return hashedPassword.length;
+    return (hashedPassword instanceof String || typeof hashedPassword === 'string') && hashedPassword.length;
   }, 'Password cannot be blank');
 
 // Validate email is not taken

--- a/app/templates/server/api/user(auth)/user.model.spec.js
+++ b/app/templates/server/api/user(auth)/user.model.spec.js
@@ -11,6 +11,12 @@ var user = new User({
   password: 'password'
 });
 
+var userWithoutEmail = new User({
+  provider: 'local',
+  name: 'Fake User',
+  password: 'password'
+});
+
 describe('User Model', function() {
   before(function(done) {
     // Clear users before testing
@@ -43,12 +49,19 @@ describe('User Model', function() {
   });
 
   it('should fail when saving without an email', function(done) {
-    user.email = '';
-    user.save(function(err) {
+    userWithoutEmail.save(function(err) {
       should.exist(err);
       done();
     });
-  });
+  });<% if (filters.oauth) { %>
+
+  it('should pass when saving without an email using a provider', function(done) {
+    userWithoutEmail.provider = 'facebook';
+    userWithoutEmail.save(function(err) {
+      should.not.exist(err);
+      done();
+    });
+  });<% } %>
 
   it("should authenticate user if password is valid", function() {
     return user.authenticate('password').should.be.true;


### PR DESCRIPTION
With local strategy, user validation fails when saving with an empty email but not when email is missing.