### PR TITLE
fix(css): fixing style error for google+ oauth

### DIFF
--- a/app/templates/client/app/account(auth)/login/login(css).css
+++ b/app/templates/client/app/account(auth)/login/login(css).css
@@ -10,7 +10,7 @@
   border-color: #0271bf;
 }
 <% } if (filters.googleAuth) { %>
-.btn-google-plus {
+.google-plus-btn {
   color: #fff;
   background-color: #dd4b39;
   border-color: #c53727;

--- a/app/templates/client/app/account(auth)/login/login(html).html
+++ b/app/templates/client/app/account(auth)/login/login(html).html
@@ -47,7 +47,7 @@
           <a class="btn btn-facebook" href="" ng-click="loginOauth('facebook')">
             <i class="fa fa-facebook"></i> Connect with Facebook
           </a><% } %><% if (filters.googleAuth) {%>
-          <a class="btn btn-google-plus" href="" ng-click="loginOauth('google')">
+          <a class="btn google-plus-btn" href="" ng-click="loginOauth('google')">
             <i class="fa fa-google-plus"></i> Connect with Google+
           </a><% } %><% if (filters.twitterAuth) {%>
           <a class="btn btn-twitter" href="" ng-click="loginOauth('twitter')">

--- a/app/templates/client/app/account(auth)/login/login(jade).jade
+++ b/app/templates/client/app/account(auth)/login/login(jade).jade
@@ -44,7 +44,7 @@ div(ng-include='"components/navbar/navbar.html"')
             i.fa.fa-facebook
             |  Connect with Facebook
           = ' '<% } %><% if (filters.googleAuth) {%>
-          a.btn.btn-google-plus(href='', ng-click='loginOauth("google")')
+          a.btn.google-plus-btn(href='', ng-click='loginOauth("google")')
             i.fa.fa-google-plus
             |  Connect with Google+
           = ' '<% } %><% if (filters.twitterAuth) {%>

--- a/app/templates/client/app/account(auth)/login/login(less).less
+++ b/app/templates/client/app/account(auth)/login/login(less).less
@@ -22,7 +22,7 @@
 .btn-twitter {
   .button-variant(@btnText; @btnTwitterBackground; @btnTwitterBackgroundHighlight);
 }<% } if (filters.googleAuth) { %>
-.btn-google-plus {
+.google-plus-btn {
   .button-variant(@btnText; @btnGooglePlusBackground; @btnGooglePlusBackgroundHighlight);
 }<% } %>
 .btn-github {

--- a/app/templates/client/app/account(auth)/login/login(sass).scss
+++ b/app/templates/client/app/account(auth)/login/login(sass).scss
@@ -22,7 +22,7 @@ $btnGithubBackgroundHighlight:      #ccc;
 .btn-twitter {
   @include button-variant($btnText, $btnTwitterBackground, $btnTwitterBackgroundHighlight);
 }<% } if (filters.googleAuth) { %>
-.btn-google-plus {
+.google-plus-btn {
   @include button-variant($btnText, $btnGooglePlusBackground, $btnGooglePlusBackgroundHighlight);
 }<% } %>
 .btn-github {

--- a/app/templates/client/app/account(auth)/login/login(stylus).styl
+++ b/app/templates/client/app/account(auth)/login/login(stylus).styl
@@ -11,7 +11,7 @@
     background-color: #2daddc;
     border-color: #0271bf;
 <% } if (filters.googleAuth) { %>
-.btn-google-plus
+.google-plus-btn
     color: #fff;
     background-color: #dd4b39;
     border-color: #c53727;

--- a/app/templates/client/app/account(auth)/signup/signup(html).html
+++ b/app/templates/client/app/account(auth)/signup/signup(html).html
@@ -68,7 +68,7 @@
           <a class="btn btn-facebook" href="" ng-click="loginOauth('facebook')">
             <i class="fa fa-facebook"></i> Connect with Facebook
           </a><% } %><% if (filters.googleAuth) {%>
-          <a class="btn btn-google-plus" href="" ng-click="loginOauth('google')">
+          <a class="btn google-plus-btn" href="" ng-click="loginOauth('google')">
             <i class="fa fa-google-plus"></i> Connect with Google+
           </a><% } %><% if (filters.twitterAuth) {%>
           <a class="btn btn-twitter" href="" ng-click="loginOauth('twitter')">

--- a/app/templates/client/app/account(auth)/signup/signup(jade).jade
+++ b/app/templates/client/app/account(auth)/signup/signup(jade).jade
@@ -47,7 +47,7 @@ div(ng-include='"components/navbar/navbar.html"')
             i.fa.fa-facebook
             |  Connect with Facebook
           = ' '<% } %><% if (filters.googleAuth) {%>
-          a.btn.btn-google-plus(href='', ng-click='loginOauth("google")')
+          a.btn.google-plus-btn(href='', ng-click='loginOauth("google")')
             i.fa.fa-google-plus
             |  Connect with Google+
           = ' '<% } %><% if (filters.twitterAuth) {%>


### PR DESCRIPTION
When generating a default project with Google+ OAuth (I tested the css and sass versions), the button does not appear on the /login or /signup pages. I fixed it by changing the name of the class from btn-google-plus to google-plus-btn.

I am using firefox 35.0.1 on linux. `yo` version is 1.4.5.

Can anyone else replicate this?