### PR TITLE
feat(gen) add Dockerfile and docker-compose.yml support

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -160,7 +160,8 @@ module.exports = function (grunt) {
         testing: 'jasmine',
         auth: true,
         oauth: ['googleAuth', 'twitterAuth'],
-        socketio: true
+        socketio: true,
+        docker: false
       };
 
       var deps = [

--- a/app/index.js
+++ b/app/index.js
@@ -212,8 +212,17 @@ var AngularFullstackGenerator = yeoman.generators.Base.extend({
           return answers.odms && answers.odms.length !== 0;
         },
         default: true
+      }, {
+        type: 'confirm',
+        name: 'docker',
+        message: 'Would you like to include Docker support?',
+        when: function (answers) {
+          return answers.odms && answers.odms.length !== 0;
+        },
+        default: false
       }], function (answers) {
         if(answers.socketio) this.filters.socketio = true;
+        if(answers.docker) this.filters.docker = true;
         if(answers.auth) this.filters.auth = true;
         if(answers.odms && answers.odms.length > 0) {
           var models;

--- a/app/templates/.dockerignore(docker)
+++ b/app/templates/.dockerignore(docker)
@@ -1,0 +1,2 @@
+.DS_Store
+node_modules

--- a/app/templates/Dockerfile(docker)
+++ b/app/templates/Dockerfile(docker)
@@ -1,0 +1,4 @@
+# Production Dockerfile - Used in the dist directory after grunt build
+FROM node:0.12-onbuild
+ENV NODE_ENV production
+EXPOSE 8080

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -391,7 +391,10 @@ module.exports = function (grunt) {
         }, {
           expand: true,
           dest: '<%%= yeoman.dist %>',
-          src: [
+          src: [<% if (filters.docker) { %>
+            'Dockerfile',
+            '.dockerignore',
+            'docker-compose.yml',<% } %>
             'package.json',
             'server/**/*'
           ]

--- a/app/templates/docker-compose.yml(docker)
+++ b/app/templates/docker-compose.yml(docker)
@@ -1,0 +1,13 @@
+# This file works in the dist directory after grunt build is finished.
+# Usage:
+#   pip install docker-compose
+#   docker-compose up
+<% if (filters.mongoose) { %>
+<%= _.slugify(appname) %>mongodb:
+  image: mongo:latest<% } %>
+<%= _.slugify(appname) %>:
+  build: .
+  links:
+   - "<%= _.slugify(appname) %>mongodb:mongodb"
+  ports:
+   - "8080:8080"

--- a/app/templates/server/config/environment/production.js
+++ b/app/templates/server/config/environment/production.js
@@ -18,7 +18,11 @@ module.exports = {
     uri:    process.env.MONGOLAB_URI ||
             process.env.MONGOHQ_URL ||
             process.env.OPENSHIFT_MONGODB_DB_URL +
-            process.env.OPENSHIFT_APP_NAME ||
+            process.env.OPENSHIFT_APP_NAME ||<% if (filters.docker) { %>
+            (process.env.MONGODB_PORT_27017_TCP_ADDR ? 'mongodb://' +
+              process.env.MONGODB_PORT_27017_TCP_ADDR + ':' +
+              process.env.MONGODB_PORT_27017_TCP_PORT +
+              '/<%= _.slugify(appname) %>' : null) ||<% } %>
             'mongodb://localhost/<%= _.slugify(appname) %>'
   }
 };

--- a/test/test-file-creation.js
+++ b/test/test-file-creation.js
@@ -22,7 +22,8 @@ describe('angular-fullstack generator', function () {
     odms: [ 'mongoose' ],
     auth: true,
     oauth: [],
-    socketio: true
+    socketio: true,
+    docker: false
   }, dependenciesInstalled = false;
 
   function copySync(s, d) { fs.writeFileSync(d, fs.readFileSync(s)); }
@@ -304,6 +305,15 @@ describe('angular-fullstack generator', function () {
       ]);
     }
 
+    /* Docker support files */
+    if (ops.docker) {
+      files = files.concat([
+        'Dockerfile',
+        '.dockerignore',
+        'docker-compose.yml'
+      ]);
+    }
+
     return files;
   }
 
@@ -502,6 +512,7 @@ describe('angular-fullstack generator', function () {
         auth: true,
         oauth: ['twitterAuth', 'facebookAuth', 'googleAuth'],
         socketio: true,
+        docker: false,
         bootstrap: true,
         uibootstrap: true
       };
@@ -574,6 +585,7 @@ describe('angular-fullstack generator', function () {
         auth: true,
         oauth: ['twitterAuth', 'facebookAuth', 'googleAuth'],
         socketio: true,
+        docker: false,
         bootstrap: true,
         uibootstrap: true
       };
@@ -647,6 +659,7 @@ describe('angular-fullstack generator', function () {
         auth: false,
         oauth: [],
         socketio: false,
+        docker: false,
         bootstrap: false,
         uibootstrap: false
       };
@@ -720,6 +733,7 @@ describe('angular-fullstack generator', function () {
         auth: false,
         oauth: [],
         socketio: false,
+        docker: false,
         bootstrap: true,
         uibootstrap: true
       };
@@ -767,7 +781,6 @@ describe('angular-fullstack generator', function () {
         //  runTest('grunt test:e2e:prod', this, done, 240000);
         //});
       }
-
     });
   });
 });


### PR DESCRIPTION
Add support to run generated Angular-Fullstack applications as Docker containers by including
Dockerfile, docker-compose.yml and .dockerignore. When the application is built with grunt
build, these files are copied to the dist directory. The Docker container can then be built
and started there with the "docker-compose up" command. When Mongoose is used, Docker Compose
will also launch a MongoDB container, eliminating the need to install MongoDB on the local
machine. Note that Docker and Docker Compose must be installed for Docker support to work.
They are available on Linux, OS X and Windows.