### PR TITLE
fix(gulp): add babel runtime options

### DIFF
--- a/app/templates/gulpfile.babel(gulp).js
+++ b/app/templates/gulpfile.babel(gulp).js
@@ -120,7 +120,9 @@ let styles = lazypipe()
 
 let transpile = lazypipe()
     .pipe(plugins.sourcemaps.init)<% if(filters.babel) { %>
-    .pipe(plugins.babel)<% } else { %>
+    .pipe(plugins.babel, {
+        optional: ['es7.classProperties']
+    })<% } else { %>
     .pipe(plugins.coffee, {bare: true})<% } %>
     .pipe(plugins.sourcemaps.write, '.');<% } %>
 

--- a/app/templates/gulpfile.babel(gulp).js
+++ b/app/templates/gulpfile.babel(gulp).js
@@ -394,7 +394,7 @@ gulp.task('build:client', ['transpile:client', 'styles', 'html'], () => {
 
     let assets = plugins.useref.assets({searchPath: ['client', '.tmp']});
 
-    return gulp.src(paths.mainView)<% if(filters.jade) { %>
+    return gulp.src(paths.client.mainView)<% if(filters.jade) { %>
         .pipe(plugins.jade({pretty: true}))<% } %>
         .pipe(assets)
             .pipe(appFilter)


### PR DESCRIPTION
without `es7.classProperties`, babel won't compile the default controller template