### PR TITLE
fix(e2e): force e2e tests to wait for angular

### DIFF
--- a/app/templates/e2e/account(auth)/login/login.spec(jasmine).js
+++ b/app/templates/e2e/account(auth)/login/login.spec(jasmine).js
@@ -26,7 +26,14 @@ describe('Login View', function() {
            if (filters.sequelizeModels) { %>return UserModel.create(testUser);<% } %>
       })
       .then(loadPage)
-      .finally(done);
+      .finally(function() {
+        browser.wait(function() {
+          //console.log('waiting for angular...');
+          return browser.executeScript('return !!window.angular');
+
+        }, 5000).then(done);
+
+      });
   });
 
   it('should include login form with correct inputs and submit button', function() {

--- a/app/templates/e2e/account(auth)/logout/logout.spec(jasmine).js
+++ b/app/templates/e2e/account(auth)/logout/logout.spec(jasmine).js
@@ -26,7 +26,11 @@ describe('Logout View', function() {
       .then(function() {
         return login(testUser);
       })
-      .finally(done);
+      .finally(function() {
+        browser.wait(function() {
+            return browser.executeScript('return !!window.angular');
+        }, 5000).then(done);
+      });
   });
 
   describe('with local auth', function() {

--- a/app/templates/e2e/account(auth)/signup/signup.spec(jasmine).js
+++ b/app/templates/e2e/account(auth)/signup/signup.spec(jasmine).js
@@ -20,8 +20,11 @@ describe('Signup View', function() {
     confirmPassword: 'test'
   };
 
-  beforeEach(function() {
+  beforeEach(function(done) {
     loadPage();
+    browser.wait(function() {
+        return browser.executeScript('return !!window.angular');
+    }, 5000).then(done);
   });
 
   it('should include signup form with correct inputs and submit button', function() {


### PR DESCRIPTION
jasmine e2e tests will occasionally fail with a "failed to sync" error
declaring `window.angular is undefined.`. Update e2e tests to force them
to wait for angular to be declared.