### PR TITLE
fix(client:util.urlParse): special treatment for IE

### DIFF
--- a/app/templates/client/components/util/util.service.js
+++ b/app/templates/client/components/util/util.service.js
@@ -26,6 +26,12 @@ function UtilService($window) {
     urlParse(url) {
       var a = document.createElement('a');
       a.href = url;
+
+      // Special treatment for IE, see http://stackoverflow.com/a/13405933 for details
+      if (a.host === '') {
+        a.href = a.href;
+      }
+
       return a;
     },
 


### PR DESCRIPTION
`isSameOrigin` always returns `false` in IE, thus user is never able to login.

> IE doesn't populate all link properties when setting .href with a relative URL,
> however .href will return an absolute URL which then can be used on itself
> to populate these additional fields.

Thanks to http://stackoverflow.com/a/13405933