### PR TITLE
fix(gulp:mocha): have tests clean up once complete

### DIFF
--- a/app/templates/gulpfile.babel(gulp).js
+++ b/app/templates/gulpfile.babel(gulp).js
@@ -42,8 +42,8 @@ const paths = {
         scripts: [`${serverPath}/**/!(*.spec|*.integration).js`],
         json: [`${serverPath}/**/*.json`],
         test: {
-          integration: `${serverPath}/**/*.integration.js`,
-          unit: `${serverPath}/**/*.spec.js`
+          integration: [`${serverPath}/**/*.integration.js`, 'mocha.global.js'],
+          unit: [`${serverPath}/**/*.spec.js`, 'mocha.global.js']
         }
     },
     karma: 'karma.conf.js',

--- a/app/templates/mocha.global(gulp).js
+++ b/app/templates/mocha.global(gulp).js
@@ -1,0 +1,8 @@
+import app from './';<% if (filters.mongoose) { %>
+import mongoose from 'mongoose';<% } %>
+
+after(function(done) {
+  app.angularFullstack.on('close', () => done());<% if (filters.mongoose) { %>
+  mongoose.connection.close();<% } %>
+  app.angularFullstack.close();
+});

--- a/app/templates/server/app.js
+++ b/app/templates/server/app.js
@@ -34,7 +34,7 @@ require('./routes')(app);
 
 // Start server
 function startServer() {
-  server.listen(config.port, config.ip, function() {
+  app.angularFullstack = server.listen(config.port, config.ip, function() {
     console.log('Express server listening on %d, in %s mode', config.port, app.get('env'));
   });
 }


### PR DESCRIPTION
mocha unit and integration tests will hang unless express (and
optionally mongoose) are closed once the tests are complete