### PR TITLE
the imagemin task error

### DIFF
--- a/app/templates/Gruntfile(grunt).js
+++ b/app/templates/Gruntfile(grunt).js
@@ -325,7 +325,7 @@ module.exports = function (grunt) {
         files: [{
           expand: true,
           cwd: '<%%= yeoman.client %>/assets/images',
-          src: '{,*/}*.{png,jpg,jpeg,gif,svg}',
+          src: '*/*.{png,jpg,jpeg,gif,svg}',
           dest: '<%%= yeoman.dist %>/<%%= yeoman.client %>/assets/images'
         }]
       }

--- a/app/templates/Gruntfile(grunt).js
+++ b/app/templates/Gruntfile(grunt).js
@@ -325,7 +325,7 @@ module.exports = function (grunt) {
         files: [{
           expand: true,
           cwd: '<%%= yeoman.client %>/assets/images',
-          src: '*/*.{png,jpg,jpeg,gif,svg}',
+          src: '**/*.{png,jpg,jpeg,gif,svg}',
           dest: '<%%= yeoman.dist %>/<%%= yeoman.client %>/assets/images'
         }]
       }


### PR DESCRIPTION
```
Running "imagemin:dist" (imagemin) task
Fatal error: Cannot read property 'contents' of undefined
```

see this link for details.

https://github.com/gruntjs/grunt-contrib-imagemin/issues/208#issuecomment-170981210