### PR TITLE
ValidationError fix for npm test in new projects

### DIFF
--- a/app/templates/server/api/user(auth)/user.model.spec(mongooseModels).js
+++ b/app/templates/server/api/user(auth)/user.model.spec(mongooseModels).js
@@ -36,14 +36,14 @@ describe('User Model', function() {
     return <%= expect() %>user.saveAsync()
       .then(function() {
         var userDup = genUser();
-        return userDup.saveAsync();
+        return User.create(userDup);
       })<%= to() %>.be.rejected;
   });
 
   describe('#email', function() {
     it('should fail when saving without an email', function() {
       user.email = '';
-      return <%= expect() %>user.saveAsync()<%= to() %>.be.rejected;
+      return <%= expect() %>User.create(user)<%= to() %>.be.rejected;
     });
   });
 


### PR DESCRIPTION
Environment Details
* Linux ... 3.19.0-43-generic #49~14.04.1-Ubuntu SMP Thu Dec 31 15:44:49 UTC 2015 x86_64 x86_64 x86_64 GNU/Linux
* node@4.2.4
* npm@3.5.3
* generator-angular-fullstack@3.3.0-beta.0


1. Ran all the steps for generating a new project as per readme instructions
  * Included basic user authentication, oauth services, selected Jasmine for tests
2. Ran the `npm test` command

```
  User Model
    ✓ should begin with no users
    ✓ should fail when saving a duplicate user (57ms)
Unhandled rejection ValidationError: The specified email address is already in use.
    at MongooseError.ValidationError (/home/dev/sandbox/meadowhark/node_modules/mongoose/lib/error/validation.js:23:11)
    at model.Document.invalidate (/home/dev/sandbox/meadowhark/node_modules/mongoose/lib/document.js:1293:32)
    at /home/dev/sandbox/meadowhark/node_modules/mongoose/lib/document.js:1168:16
    at validate (/home/dev/sandbox/meadowhark/node_modules/mongoose/lib/schematype.js:662:7)
    at /home/dev/sandbox/meadowhark/node_modules/mongoose/lib/schematype.js:690:11
    at /home/dev/sandbox/meadowhark/server/api/user/user.model.js:75:18
    at bound (domain.js:287:14)
    at runBound (domain.js:300:12)
    at tryCatcher (/home/dev/sandbox/meadowhark/node_modules/bluebird/js/main/util.js:26:23)
    at Promise._settlePromiseFromHandler (/home/dev/sandbox/meadowhark/node_modules/bluebird/js/main/promise.js:507:31)
    at Promise._settlePromiseAt (/home/dev/sandbox/meadowhark/node_modules/bluebird/js/main/promise.js:581:18)
    at Promise._settlePromises (/home/dev/sandbox/meadowhark/node_modules/bluebird/js/main/promise.js:697:14)
    at Async._drainQueue (/home/dev/sandbox/meadowhark/node_modules/bluebird/js/main/async.js:123:16)
    at Async._drainQueues (/home/dev/sandbox/meadowhark/node_modules/bluebird/js/main/async.js:133:10)
    at Immediate.Async.drainQueues [as _onImmediate] (/home/dev/sandbox/meadowhark/node_modules/bluebird/js/main/async.js:15:14)
    at processImmediate [as _immediateCallback] (timers.js:383:17)
    #email
      ✓ should fail when saving without an email
Unhandled rejection ValidationError: Email cannot be blank
    at MongooseError.ValidationError (/home/dev/sandbox/meadowhark/node_modules/mongoose/lib/error/validation.js:23:11)
    at model.Document.invalidate (/home/dev/sandbox/meadowhark/node_modules/mongoose/lib/document.js:1293:32)
    at /home/dev/sandbox/meadowhark/node_modules/mongoose/lib/document.js:1168:16
    at validate (/home/dev/sandbox/meadowhark/node_modules/mongoose/lib/schematype.js:662:7)
    at /home/dev/sandbox/meadowhark/node_modules/mongoose/lib/schematype.js:693:9
    at Array.forEach (native)
    at SchemaString.SchemaType.doValidate (/home/dev/sandbox/meadowhark/node_modules/mongoose/lib/schematype.js:667:19)
    at /home/dev/sandbox/meadowhark/node_modules/mongoose/lib/document.js:1166:9
    at doNTCallback0 (node.js:419:9)
    at process._tickDomainCallback (node.js:389:13)
    #password
      ✓ should authenticate user if valid
      ✓ should not authenticate user if invalid
      ✓ should remain the same hash unless the password is updated
  20 passing (401ms)
```

Following changes fixes this error.
Please see https://github.com/angular-fullstack/generator-angular-fullstack/issues/1498 