### PR TITLE
refactor(model:user): exclude password info by default

### DIFF
--- a/app/templates/server/api/user(auth)/user.controller.js
+++ b/app/templates/server/api/user(auth)/user.controller.js
@@ -25,16 +25,8 @@ function handleError(res, statusCode) {
  * restriction: 'admin'
  */
 export function index(req, res) {
-  <% if (filters.mongooseModels) { %>User.findAsync({}, '-salt -password')<% }
-     if (filters.sequelizeModels) { %>User.findAll({
-    attributes: [
-      '_id',
-      'name',
-      'email',
-      'role',
-      'provider'
-    ]
-  })<% } %>
+  <% if (filters.mongooseModels) { %>User.findAsync()<% }
+     if (filters.sequelizeModels) { %>User.findAll()<% } %>
     .then(users => {
       res.status(200).json(users);
     })
@@ -132,19 +124,8 @@ export function changePassword(req, res, next) {
 export function me(req, res, next) {
   var userId = req.user._id;
 
-  <% if (filters.mongooseModels) { %>User.findOneAsync({ _id: userId }, '-salt -password')<% }
-     if (filters.sequelizeModels) { %>User.find({
-    where: {
-      _id: userId
-    },
-    attributes: [
-      '_id',
-      'name',
-      'email',
-      'role',
-      'provider'
-    ]
-  })<% } %>
+  <% if (filters.mongooseModels) { %>User.findOneAsync({ _id: userId })<% }
+     if (filters.sequelizeModels) { %>User.find({ where: { _id: userId } })<% } %>
     .then(user => { // don't ever give out the password or salt
       if (!user) {
         return res.status(401).end();

--- a/app/templates/server/api/user(auth)/user.model(mongooseModels).js
+++ b/app/templates/server/api/user(auth)/user.model(mongooseModels).js
@@ -16,9 +16,9 @@ var UserSchema = new Schema({
     type: String,
     default: 'user'
   },
-  password: String,
+  password: {type: String, select: false},
   provider: String,
-  salt: String<% if (filters.oauth) { %>,<% if (filters.facebookAuth) { %>
+  salt: {type: String, select: false}<% if (filters.oauth) { %>,<% if (filters.facebookAuth) { %>
   facebook: {},<% } %><% if (filters.twitterAuth) { %>
   twitter: {},<% } %><% if (filters.googleAuth) { %>
   google: {},<% } %>

--- a/app/templates/server/api/user(auth)/user.model(sequelizeModels).js
+++ b/app/templates/server/api/user(auth)/user.model(sequelizeModels).js
@@ -1,5 +1,6 @@
 'use strict';
 
+import _ from 'lodash';
 import crypto from 'crypto';<% if (filters.oauth) { %>
 var authTypes = ['github', 'twitter', 'facebook', 'google'];<% } %>
 
@@ -228,6 +229,12 @@ module.exports = function(sequelize, DataTypes) {
         } else {
           fn(null);
         }
+      },
+
+      toJSON: function() {
+        var excludedAttributes = ['salt', 'password'];
+
+        return _.omit(this.dataValues, excludedAttributes);
       }
     }
   });

--- a/app/templates/server/api/user(auth)/user.model.spec(mongooseModels).js
+++ b/app/templates/server/api/user(auth)/user.model.spec(mongooseModels).js
@@ -52,6 +52,13 @@ describe('User Model', function() {
       return user.saveAsync();
     });
 
+    it('should exclude salt and hashedPassword by default', function() {
+      User.find({name: user.name}, function(err, _user) {
+        _user.should.not.have.property('salt');
+        _user.should.not.have.property('hashedPassword');
+      });
+    });
+
     it('should authenticate user if valid', function() {
       <%= expect() %>user.authenticate('password')<%= to() %>.be.true;
     });

--- a/app/templates/server/api/user(auth)/user.model.spec(sequelizeModels).js
+++ b/app/templates/server/api/user(auth)/user.model.spec(sequelizeModels).js
@@ -54,6 +54,13 @@ describe('User Model', function() {
       return user.save();
     });
 
+    it('should exclude salt and hashedPassword by default', function() {
+      User.find({name: user.name}, function(err, _user) {
+        _user.should.not.have.property('salt');
+        _user.should.not.have.property('hashedPassword');
+      });
+    });
+
     it('should authenticate user if valid', function() {
       <%= expect() %>user.authenticate('password')<%= to() %>.be.true;
     });

--- a/app/templates/server/auth(auth)/local/passport.js
+++ b/app/templates/server/auth(auth)/local/passport.js
@@ -4,8 +4,8 @@ import {Strategy as LocalStrategy} from 'passport-local';
 function localAuthenticate(User, email, password, done) {
   <% if (filters.mongooseModels) { %>User.findOneAsync({
     email: email.toLowerCase()
-  })<% }
-     if (filters.sequelizeModels) { %>User.find({
+  }, '+salt +hashedPassword')<% }
+     if (filters.sequelizeModels) { %>User.unscoped().find({
     where: {
       email: email.toLowerCase()
     }


### PR DESCRIPTION
based on PR #1049 from @Awk34 commit (5fecaba).

Hi, this is another attempt at excluding the password info by default and not just at query time. The sequelize way of doing it is not pretty but seems to be the [recommended](https://github.com/sequelize/sequelize/issues/1462#issuecomment-168383832) way. And it does not look like there will be a different way anytime soon.