### PR TITLE
Use _.extend() instead of _.merge() for PUT requests

### DIFF
--- a/endpoint/templates/basename.controller.js
+++ b/endpoint/templates/basename.controller.js
@@ -24,7 +24,7 @@ function respondWithResult(res, statusCode) {
 
 function saveUpdates(updates) {
   return function(entity) {
-    <% if (filters.mongooseModels) { %>v_.extend(entity, updates);
+    <% if (filters.mongooseModels) { %>_.extend(entity, updates);
     return entity.saveAsync()
       .spread(entity => {<% }
        if (filters.sequelizeModels) { %>return entity.updateAttributes(updates)

--- a/endpoint/templates/basename.controller.js
+++ b/endpoint/templates/basename.controller.js
@@ -24,12 +24,12 @@ function respondWithResult(res, statusCode) {
 
 function saveUpdates(updates) {
   return function(entity) {
-    <% if (filters.mongooseModels) { %>var updated = _.merge(entity, updates);
-    return updated.saveAsync()
-      .spread(updated => {<% }
+    <% if (filters.mongooseModels) { %>v_.extend(entity, updates);
+    return entity.saveAsync()
+      .spread(entity => {<% }
        if (filters.sequelizeModels) { %>return entity.updateAttributes(updates)
-      .then(updated => {<% } %>
-        return updated;
+      .then(entity => {<% } %>
+        return entity;
       });
   };
 }


### PR DESCRIPTION
This is undoubtedly desired behavior for 99% of all endpoint use-cases and should be defaulted.