### PR TITLE
feat(gen): add 'es6' to generator-ng-component filters

### DIFF
--- a/app/generator.js
+++ b/app/generator.js
@@ -364,6 +364,8 @@ export default class Generator extends Base {
         if(this.filters.sass) extensions.push('scss');
         if(this.filters.less) extensions.push('less');
 
+        filters.push('es6'); // Generate ES6 syntax code
+
         this.composeWith('ng-component', {
           options: {
             'routeDirectory': appPath,


### PR DESCRIPTION
This won't do anything until we release a new version of generator-ng-component and bump the version required here