### PR TITLE
docs(readme): add module name question to route generator example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -164,6 +164,7 @@ Generates a new route.
 Example:
 ```bash
 yo angular-fullstack:route myroute
+[?] What module name would you like to use? myApp
 [?] Where would you like to create this route? client/app/
 [?] What will the url of your route be? /myroute
 ```


### PR DESCRIPTION
The route generator asks for a module name. Add it to match the usage experience.

I read that I should push fixes to canary, but that doesn't apply to a docfix for the current version, does it?