### PR TITLE
fix(package): always make html2js a dependency

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -152,8 +152,8 @@
     "karma-requirejs": "~0.2.2",
     "karma-jade-preprocessor": "0.0.11",
     "karma-phantomjs-launcher": "~1.0.0",<% if (filters.jade) { %>
-    "karma-ng-jade2js-preprocessor": "^0.2.0",<% } else { %>
-    "karma-ng-html2js-preprocessor": "~0.2.0",<% } %>
+    "karma-ng-jade2js-preprocessor": "^0.2.0",<% } %>
+    "karma-ng-html2js-preprocessor": "~0.2.0",
     "karma-spec-reporter": "~0.0.20",
     "sinon-chai": "^2.8.0",
     "mocha": "^2.2.5",<% if (filters.mocha) { %>


### PR DESCRIPTION

When you generate with the Jade option, the Karma.conf file still keeps the config for ng-html2js for any html files that may be present. This fix makes it so we always add the ng-html2js dependency to package.json to fix that.

Closes #1722