### PR TITLE
fix(user): fix email and password validation

### DIFF
--- a/app/templates/gulpfile.babel(gulp).js
+++ b/app/templates/gulpfile.babel(gulp).js
@@ -486,7 +486,7 @@ gulp.task('wiredep:client', () => {
                 /bootstrap\.css/<% if(filters.sass) { %>,
                 /bootstrap-sass-official/<% } if(filters.oauth) { %>,
                 /bootstrap-social\.css/<% }}} %>
-            ]
+            ],
             ignorePath: clientPath
         }))
         .pipe(gulp.dest(`${clientPath}/`));
@@ -503,7 +503,7 @@ gulp.task('wiredep:test', () => {
                 /bootstrap\.css/<% if(filters.sass) { %>,
                 /bootstrap-sass-official/<% } if(filters.oauth) { %>,
                 /bootstrap-social\.css/<% }}} %>
-            ]
+            ],
             devDependencies: true
         }))
         .pipe(gulp.dest('./'));

--- a/app/templates/server/api/user(auth)/user.model.spec(mongooseModels).js
+++ b/app/templates/server/api/user(auth)/user.model.spec(mongooseModels).js
@@ -41,32 +41,137 @@ describe('User Model', function() {
   });
 
   describe('#email', function() {
-    it('should fail when saving without an email', function() {
+    it('should fail when saving with a blank email', function() {
       user.email = '';
       return <%= expect() %>user.save()<%= to() %>.be.rejected;
     });
+
+    it('should fail when saving without an email', function() {
+      user.email = null;
+      return <%= expect() %>user.save()<%= to() %>.be.rejected;
+    });<% if (filters.oauth && filters.googleAuth) { %>
+
+    context('given user provider is google', function() {
+      beforeEach(function() {
+        user.provider = 'google';
+      });
+
+      it('should succeed when saving without an email', function() {
+        user.email = null;
+        return <%= expect() %>user.save()<%= to() %>.be.fulfilled;
+      });
+    });<% } %><% if (filters.oauth && filters.facebookAuth) { %>
+
+    context('given user provider is facebook', function() {
+      beforeEach(function() {
+        user.provider = 'facebook';
+      });
+
+      it('should succeed when saving without an email', function() {
+        user.email = null;
+        return <%= expect() %>user.save()<%= to() %>.be.fulfilled;
+      });
+    });<% } %><% if (filters.oauth && filters.twitterAuth) { %>
+
+    context('given user provider is twitter', function() {
+      beforeEach(function() {
+        user.provider = 'twitter';
+      });
+
+      it('should succeed when saving without an email', function() {
+        user.email = null;
+        return <%= expect() %>user.save()<%= to() %>.be.fulfilled;
+      });
+    });<% } %><% if (filters.oauth) { %>
+
+    context('given user provider is github', function() {
+      beforeEach(function() {
+        user.provider = 'github';
+      });
+
+      it('should succeed when saving without an email', function() {
+        user.email = null;
+        return <%= expect() %>user.save()<%= to() %>.be.fulfilled;
+      });
+    });<% } %>
   });
 
   describe('#password', function() {
-    beforeEach(function() {
-      return user.save();
+    it('should fail when saving with a blank password', function() {
+      user.password = '';
+      return <%= expect() %>user.save()<%= to() %>.be.rejected;
     });
 
-    it('should authenticate user if valid', function() {
-      <%= expect() %>user.authenticate('password')<%= to() %>.be.true;
+    it('should fail when saving without a password', function() {
+      user.password = null;
+      return <%= expect() %>user.save()<%= to() %>.be.rejected;
     });
 
-    it('should not authenticate user if invalid', function() {
-      <%= expect() %>user.authenticate('blah')<%= to() %>.not.be.true;
-    });
+    context('given the user has been previously saved', function() {
+      beforeEach(function() {
+        return user.save();
+      });
 
-    it('should remain the same hash unless the password is updated', function() {
-      user.name = 'Test User';
-      return <%= expect() %>user.save()
-        .then(function(u) {
-          return u.authenticate('password');
-        })<%= to() %>.eventually.be.true;
-    });
+      it('should authenticate user if valid', function() {
+        <%= expect() %>user.authenticate('password')<%= to() %>.be.true;
+      });
+
+      it('should not authenticate user if invalid', function() {
+        <%= expect() %>user.authenticate('blah')<%= to() %>.not.be.true;
+      });
+
+      it('should remain the same hash unless the password is updated', function() {
+        user.name = 'Test User';
+        return <%= expect() %>user.save()
+          .then(function(u) {
+            return u.authenticate('password');
+          })<%= to() %>.eventually.be.true;
+      });
+    });<% if (filters.oauth && filters.googleAuth) { %>
+
+    context('given user provider is google', function() {
+      beforeEach(function() {
+        user.provider = 'google';
+      });
+
+      it('should succeed when saving without a password', function() {
+        user.password = null;
+        return <%= expect() %>user.save()<%= to() %>.be.fulfilled;
+      });
+    });<% } %><% if (filters.oauth && filters.facebookAuth) { %>
+
+    context('given user provider is facebook', function() {
+      beforeEach(function() {
+        user.provider = 'facebook';
+      });
+
+      it('should succeed when saving without a password', function() {
+        user.password = null;
+        return <%= expect() %>user.save()<%= to() %>.be.fulfilled;
+      });
+    });<% } %><% if (filters.oauth && filters.twitterAuth) { %>
+
+    context('given user provider is twitter', function() {
+      beforeEach(function() {
+        user.provider = 'twitter';
+      });
+
+      it('should succeed when saving without a password', function() {
+        user.password = null;
+        return <%= expect() %>user.save()<%= to() %>.be.fulfilled;
+      });
+    });<% } %><% if (filters.oauth) { %>
+
+    context('given user provider is github', function() {
+      beforeEach(function() {
+        user.provider = 'github';
+      });
+
+      it('should succeed when saving without a password', function() {
+        user.password = null;
+        return <%= expect() %>user.save()<%= to() %>.be.fulfilled;
+      });
+    });<% } %>
   });
 
 });

--- a/app/templates/server/api/user(auth)/user.model.spec(mongooseModels).js
+++ b/app/templates/server/api/user(auth)/user.model.spec(mongooseModels).js
@@ -46,8 +46,13 @@ describe('User Model', function() {
       return <%= expect() %>user.save()<%= to() %>.be.rejected;
     });
 
-    it('should fail when saving without an email', function() {
+    it('should fail when saving with a null email', function() {
       user.email = null;
+      return <%= expect() %>user.save()<%= to() %>.be.rejected;
+    });
+
+    it('should fail when saving without an email', function() {
+      user.email = undefined;
       return <%= expect() %>user.save()<%= to() %>.be.rejected;
     });<% if (filters.oauth && filters.googleAuth) { %>
 
@@ -102,8 +107,13 @@ describe('User Model', function() {
       return <%= expect() %>user.save()<%= to() %>.be.rejected;
     });
 
-    it('should fail when saving without a password', function() {
+    it('should fail when saving with a null password', function() {
       user.password = null;
+      return <%= expect() %>user.save()<%= to() %>.be.rejected;
+    });
+
+    it('should fail when saving without a password', function() {
+      user.password = undefined;
       return <%= expect() %>user.save()<%= to() %>.be.rejected;
     });
 


### PR DESCRIPTION

If no email and password were passed to the authentication endpoints,
the authentication would still succeed even though there was no email
and password. This fixes that to make sure that we account for blank and
null email and passwords. Also it makes sure that email
and password are not required when using other oauth providers.