### PR TITLE
fix(css): Add all style files to inject:css

### DIFF
--- a/app/templates/gulpfile.babel(gulp).js
+++ b/app/templates/gulpfile.babel(gulp).js
@@ -246,7 +246,7 @@ gulp.task('inject:tsconfig', () => {
 gulp.task('inject:css', () => {
     return gulp.src(paths.client.mainView)
         .pipe(plugins.inject(
-            gulp.src(`/${clientPath}/{app,components}/**/*.css`, {read: false})
+            gulp.src(paths.client.styles, {read: false})
                 .pipe(plugins.sort()),
             {
                 starttag: '<!-- injector:css -->',
@@ -294,7 +294,7 @@ gulp.task('tsd:test', cb => {
 });<% } %>
 
 gulp.task('styles', () => {
-    return gulp.src(paths.client.mainStyle)
+    return gulp.src(paths.client.styles)
         .pipe(styles())
         .pipe(gulp.dest('.tmp/app'));
 });<% if(filters.ts) { %>


### PR DESCRIPTION
Add all css files to the css injector, for some reason the hardcoded glob wouldn't work but I instead used the predefined one. All css files now also undergo the 'styles' pipe.

The problem this fixes is that only `app.css` used to be loaded, because it was the only one injected into `index.html`.