### PR TITLE
fix(livereload): ignore api routes and specific non-html files

### DIFF
--- a/app/templates/server/config/express.js
+++ b/app/templates/server/config/express.js
@@ -80,7 +80,13 @@ export default function(app) {
   }
 
   if ('development' === env) {
-    app.use(require('connect-livereload')());
+    app.use(require('connect-livereload')({
+      ignore: [
+        /^\/api\/(.*)/,
+        /\.js(\?.*)?$/, /\.css(\?.*)?$/, /\.svg(\?.*)?$/, /\.ico(\?.*)?$/, /\.woff(\?.*)?$/,
+        /\.png(\?.*)?$/, /\.jpg(\?.*)?$/, /\.jpeg(\?.*)?$/, /\.gif(\?.*)?$/, /\.pdf(\?.*)?$/
+      ]
+    }));
   }
 
   if ('development' === env || 'test' === env) {


### PR DESCRIPTION

closes #1636, #1764