### PR TITLE
yo angular-fullstack:directive uses deprecated method

### DIFF
--- a/directive/index.js
+++ b/directive/index.js
@@ -1,7 +1,7 @@
 'use strict';
 var yeoman = require('yeoman-generator');
 
-var Generator = yeoman.generators.Base.extend({
+var Generator = yeoman.Base.extend({
   compose: function() {
     this.composeWith('ng-component:directive', {arguments: this.arguments}, { local: require.resolve('generator-ng-component/directive') });
   }


### PR DESCRIPTION
- [x] I have read the [Contributing Documents](https://github.com/DaftMonk/generator-angular-fullstack/blob/master/contributing.md)

- [ ] My commit(s) follow the [AngularJS commit message guidelines](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/)

when doing `yo angular-fullstack:directive`, the message `(!) require('yeoman-generator').generators.Base is deprecated. Use require('yeoman-generator').Base directly` will appear. 

So i edited the file to use require('yeoman-generator').Base directly.