### PR TITLE
fix(gulp): build images before rev-replace

### DIFF
--- a/app/templates/gulpfile.babel(gulp).js
+++ b/app/templates/gulpfile.babel(gulp).js
@@ -561,7 +561,7 @@ gulp.task('build', cb => {
 
 gulp.task('clean:dist', () => del([`${paths.dist}/!(.git*|.openshift|Procfile)**`], {dot: true}));
 
-gulp.task('build:client', ['transpile:client', 'styles', 'html', 'constant'], () => {
+gulp.task('build:client', ['transpile:client', 'styles', 'html', 'constant', 'build:images'], () => {
     var manifest = gulp.src(`${paths.dist}/${clientPath}/assets/rev-manifest.json`);
 
     var appFilter = plugins.filter('**/app.js', {restore: true});


### PR DESCRIPTION
- [x] I have read the [Contributing Documents](https://github.com/DaftMonk/generator-angular-fullstack/blob/master/contributing.md)
- [x] My commit(s) follow the [AngularJS commit message guidelines](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/)

When running `gulp build` the rev manifest will be remade, but the task
"build:client" which uses this file doesn't depend on "build:images"
which populates this file. The result is that when running `build`,
rev-replace will be unable to replace images as it doesn't wait for
images to be filled in.
Solution is to simply have "build:client" depend upon "build:images"