### PR TITLE
fix(ts): fix typo of gulp's typescript test configuration file

### DIFF
--- a/app/templates/gulpfile.babel(gulp).js
+++ b/app/templates/gulpfile.babel(gulp).js
@@ -315,7 +315,7 @@ gulp.task('transpile:client', ['constant', 'copy:constant'], () => {
 });
 
 gulp.task('transpile:client:test', ['tsd:test'], () => {
-    let tsTestProject = plugins.typescript.createProject('./tsconfig.client.json');
+    let tsTestProject = plugins.typescript.createProject('./tsconfig.client.test.json');
     return tsTestProject.src()
         .pipe(plugins.sourcemaps.init())
         .pipe(plugins.typescript(tsTestProject)).js


### PR DESCRIPTION
Fixes two bugs leading to gulp + typescript builds to not launch tests properly.

Closes issue #1748