### PR TITLE
fixed runtime warning when not making return explicit

### DIFF
--- a/templates/endpoint/basename.controller.js
+++ b/templates/endpoint/basename.controller.js
@@ -17,7 +17,7 @@ function respondWithResult(res, statusCode) {
   statusCode = statusCode || 200;
   return function(entity) {
     if (entity) {
-      res.status(statusCode).json(entity);
+      return res.status(statusCode).json(entity);
     }
   };
 }
@@ -40,7 +40,7 @@ function removeEntity(res) {
       <% if (filters.mongooseModels) { %>return entity.remove()<% }
          if (filters.sequelizeModels) { %>return entity.destroy()<% } %>
         .then(() => {
-          res.status(204).end();
+          return res.status(204).end();
         });
     }
   };
@@ -59,7 +59,7 @@ function handleEntityNotFound(res) {
 function handleError(res, statusCode) {
   statusCode = statusCode || 500;
   return function(err) {
-    res.status(statusCode).send(err);
+    return res.status(statusCode).send(err);
   };
 }<% } %>
 


### PR DESCRIPTION
- [x] I have read the [Contributing Documents](https://github.com/DaftMonk/generator-angular-fullstack/blob/master/contributing.md)
- [x] My commit(s) follow the [AngularJS commit message guidelines](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/)

Fixing runtime warning similar to the following:

```
Running "open:server" (open) task

Running "watch" task
Waiting...
SocketIO / [127.0.0.1:60178] CONNECTED
SocketIO / [127.0.0.1:60182] CONNECTED
Warning: a promise was created in a handler but was not returned from it
    at MongoStore.touch (/Users/mitch/Dev/test-personal-projects/angular-fullstack-test/node_modules/connect-mongo/src/index.js:273:18)
    at ServerResponse.end (/Users/mitch/Dev/test-personal-projects/angular-fullstack-test/node_modules/express-session/index.js:301:15)
    at ServerResponse.send (/Users/mitch/Dev/test-personal-projects/angular-fullstack-test/node_modules/express/lib/response.js:204:10)
    at ServerResponse.json (/Users/mitch/Dev/test-personal-projects/angular-fullstack-test/node_modules/express/lib/response.js:249:15)
    at thing.controller.js:19:30
    at processImmediate [as _immediateCallback] (timers.js:383:17)
From previous event:
    at index (thing.controller.js:65:6)
    at Layer.handle [as handle_request] (/Users/mitch/Dev/test-personal-projects/angular-fullstack-test/node_modules/express/lib/router/layer.js:95:5)
    at next (/Users/mitch/Dev/test-personal-projects/angular-fullstack-test/node_modules/express/lib/router/route.js:131:13)
    at Route.dispatch (/Users/mitch/Dev/test-personal-projects/angular-fullstack-test/node_modules/express/lib/router/route.js:112:3)
    at Layer.handle [as handle_request] (/Users/mitch/Dev/test-personal-projects/angular-fullstack-test/node_modules/express/lib/router/layer.js:95:5)
    at /Users/mitch/Dev/test-personal-projects/angular-fullstack-test/node_modules/express/lib/router/index.js:277:22
    at Function.process_params (/Users/mitch/Dev/test-personal-projects/angular-fullstack-test/node_modules/express/lib/router/index.js:330:12)
    at next (/Users/mitch/Dev/test-personal-projects/angular-fullstack-test/node_modules/express/lib/router/index.js:271:10)
    at Function.handle (/Users/mitch/Dev/test-personal-projects/angular-fullstack-test/node_modules/express/lib/router/index.js:176:3)
    at router (/Users/mitch/Dev/test-personal-projects/angular-fullstack-test/node_modules/express/lib/router/index.js:46:12)
    at Layer.handle [as handle_request] (/Users/mitch/Dev/test-personal-projects/angular-fullstack-test/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/Users/mitch/Dev/test-personal-projects/angular-fullstack-test/node_modules/express/lib/router/index.js:312:13)
    at /Users/mitch/Dev/test-personal-projects/angular-fullstack-test/node_modules/express/lib/router/index.js:280:7
    at Function.process_params (/Users/mitch/Dev/test-personal-projects/angular-fullstack-test/node_modules/express/lib/router/index.js:330:12)
    at next (/Users/mitch/Dev/test-personal-projects/angular-fullstack-test/node_modules/express/lib/router/index.js:271:10)
    at Layer.handle [as handle_request] (/Users/mitch/Dev/test-personal-projects/angular-fullstack-test/node_modules/express/lib/router/layer.js:91:12)
    at trim_prefix (/Users/mitch/Dev/test-personal-projects/angular-fullstack-test/node_modules/express/lib/router/index.js:312:13)
    at /Users/mitch/Dev/test-personal-projects/angular-fullstack-test/node_modules/express/lib/router/index.js:280:7
    at Function.process_params (/Users/mitch/Dev/test-personal-projects/angular-fullstack-test/node_modules/express/lib/router/index.js:330:12)
    at next (/Users/mitch/Dev/test-personal-projects/angular-fullstack-test/node_modules/express/lib/router/index.js:271:10)
    at logger (/Users/mitch/Dev/test-personal-projects/angular-fullstack-test/node_modules/morgan/index.js:144:5)
    at Layer.handle [as handle_request] (/Users/mitch/Dev/test-personal-projects/angular-fullstack-test/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/Users/mitch/Dev/test-personal-projects/angular-fullstack-test/node_modules/express/lib/router/index.js:312:13)
    at /Users/mitch/Dev/test-personal-projects/angular-fullstack-test/node_modules/express/lib/router/index.js:280:7
    at Function.process_params (/Users/mitch/Dev/test-personal-projects/angular-fullstack-test/node_modules/express/lib/router/index.js:330:12)

GET /api/things 200 6.470 ms - -
```