### PR TITLE
gulp:ts: fix ts copy of constant file and inject test client .ts files automatically.

### DIFF
--- a/app/templates/gulpfile.babel(gulp).js
+++ b/app/templates/gulpfile.babel(gulp).js
@@ -227,15 +227,11 @@ gulp.task('inject:js', () => {
         .pipe(gulp.dest(clientPath));
 });<% if(filters.ts) { %>
 
-gulp.task('inject:tsconfig', () => {
-    let src = gulp.src([
-        `${clientPath}/**/!(*.spec|*.mock).ts`,
-        `!${clientPath}/bower_components/**/*`,
-        `${clientPath}/typings/**/*.d.ts`
-    ], {read: false})
+function injectTsConfig(filesGlob, tsconfigPath){
+    let src = gulp.src(filesGlob, {read: false})
         .pipe(plugins.sort());
 
-    return gulp.src('./tsconfig.client.json')
+    return gulp.src(tsconfigPath)
         .pipe(plugins.inject(src, {
             starttag: '"files": [',
             endtag: ']',
@@ -244,6 +240,26 @@ gulp.task('inject:tsconfig', () => {
             }
         }))
         .pipe(gulp.dest('./'));
+}
+
+gulp.task('inject:tsconfig', () => {
+    return injectTsConfig([
+        `${clientPath}/**/!(*.spec|*.mock).ts`,
+       `!${clientPath}/bower_components/**/*`,
+        `${clientPath}/typings/**/*.d.ts`,
+        `!${clientPath}/test_typings/**/*.d.ts`
+    ], 
+    './tsconfig.client.json');
+});
+
+gulp.task('inject:tsconfigTest', () => {
+    return injectTsConfig([
+        `${clientPath}/**/+(*.spec|*.mock).ts`,
+        `!${clientPath}/bower_components/**/*`,
+        `!${clientPath}/typings/**/*.d.ts`,
+        `${clientPath}/test_typings/**/*.d.ts`
+    ], 
+    './tsconfig.client.test.json');
 });<% } %>
 
 gulp.task('inject:css', () => {

--- a/app/templates/gulpfile.babel(gulp).js
+++ b/app/templates/gulpfile.babel(gulp).js
@@ -305,12 +305,12 @@ gulp.task('styles', () => {
         .pipe(gulp.dest('.tmp/app'));
 });<% if(filters.ts) { %>
 
-gulp.task('copy:constant', () => {
+gulp.task('copy:constant', ['constant'], () => {
     return gulp.src(`${clientPath}/app/app.constant.js`, { dot: true })
         .pipe(gulp.dest('.tmp/app'));
 })
 
-gulp.task('transpile:client', ['tsd', 'constant', 'copy:constant'], () => {
+gulp.task('transpile:client', ['tsd', 'copy:constant'], () => {
     let tsProject = plugins.typescript.createProject('./tsconfig.client.json');
     return tsProject.src()
         .pipe(plugins.sourcemaps.init())


### PR DESCRIPTION
Closes two issues: #1830 and #1828.

The fix for issue #1830 is pretty straight-forward and think the extra task and refactoring of the old task to an external function for issue #1828 are relatively small as well. 

I am however a bit concerned that the refactoring might not necessarily comply with the preferred coding style for the repository. Should the function rather be a separate task? Or be moved into helper functions above?

Either way, I figure that the `injectTsConfig` function could be used for a future `tsconfig.server.json` and `tsconfig.server.test.json`. So think it's at least better than copy + paste.

- [x] I have read the [Contributing Documents](https://github.com/DaftMonk/generator-angular-fullstack/blob/master/contributing.md)
- [x] My commit(s) follow the [AngularJS commit message guidelines](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/)