### PR TITLE
fix: IE11 log in works for ports 80 and 443

### DIFF
--- a/templates/app/client/components/util/util.service.js
+++ b/templates/app/client/components/util/util.service.js
@@ -49,7 +49,10 @@ function UtilService($window) {
       origins.push($window.location);
       origins = origins.filter(function(o) {
         return url.hostname === o.hostname &&
-          url.port === o.port &&
+          // 2nd part of the special treatment for IE fix (see above):  
+          // This part is when using well-known ports 80 or 443 with IE, when $window.location.port==='' instead of the real port number. Probably the same cause as this IE bug:  
+          // https://connect.microsoft.com/IE/feedback/details/817343/ie11-scripting-value-of-htmlanchorelement-host-differs-between-script-created-link-and-link-from-document  
+          (url.port === o.port || (o.port === '' && (url.port === '80' || url.port === '443'))) &&  
           url.protocol === o.protocol;
       });
       return (origins.length >= 1);


### PR DESCRIPTION

Fixes logging in with IE11 when using well-known port numbers 80 and 443 where otherwise isSameOrigin() fails because of an IE bug. See issue #1880