### PR TITLE
(fix:express): reorder static middleware

### DIFF
--- a/templates/app/server/config/express.js
+++ b/templates/app/server/config/express.js
@@ -29,6 +29,18 @@ var Store = expressSequelizeSession(session.Store);<% } %>
 export default function(app) {
   var env = app.get('env');
 
+  if (env === 'development' || env === 'test') {
+    app.use(express.static(path.join(config.root, '.tmp')));
+  }
+
+  if (env === 'production') {
+    app.use(favicon(path.join(config.root, 'client', 'favicon.ico')));
+  }
+
+  app.set('appPath', path.join(config.root, 'client'));
+  app.use(express.static(app.get('appPath')));
+  app.use(morgan('dev'));
+
   app.set('views', config.root + '/server/views');<% if (filters.html) { %>
   app.engine('html', require('ejs').renderFile);
   app.set('view engine', 'html');<% } %><% if (filters.jade) { %>
@@ -73,14 +85,6 @@ export default function(app) {
     }));
   }
 
-  app.set('appPath', path.join(config.root, 'client'));
-
-  if ('production' === env) {
-    app.use(favicon(path.join(config.root, 'client', 'favicon.ico')));
-    app.use(express.static(app.get('appPath')));
-    app.use(morgan('dev'));
-  }
-
   if ('development' === env) {
     app.use(require('connect-livereload')({
       ignore: [
@@ -92,9 +96,6 @@ export default function(app) {
   }
 
   if ('development' === env || 'test' === env) {
-    app.use(express.static(path.join(config.root, '.tmp')));
-    app.use(express.static(app.get('appPath')));
-    app.use(morgan('dev'));
     app.use(errorHandler()); // Error handler - has to be last
   }
 }


### PR DESCRIPTION
- [x] I have read the [Contributing Documents](https://github.com/DaftMonk/generator-angular-fullstack/blob/master/contributing.md)
- [x] My commit(s) follow the [AngularJS commit message guidelines](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/)
- [x] The generator's tests pass (`generator-angular-fullstack$ npm test`)

Fixes an upstream issue in express-session or express-sequelize-session
where static middleware requests:
- Hit the session store,
- Overwrite one another, and
- Generate many new sessions.

Fixes #1668.