### PR TITLE
Fix for angular resource error 404 on save

### DIFF
--- a/templates/endpoint/index.js
+++ b/templates/endpoint/index.js
@@ -9,6 +9,7 @@ router.get('/', controller.index);<% if (filters.models) { %>
 router.get('/:id', controller.show);
 router.post('/', controller.create);
 router.put('/:id', controller.update);
+router.post('/:id', controller.update);
 router.patch('/:id', controller.update);
 router.delete('/:id', controller.destroy);<% } %>
 


### PR DESCRIPTION
404 Error on Angularjs $resource when using resource.$save(). Angularjs default behaviour is to use post to save/update data on server. This route wasn't generated.
