### PR TITLE
fix(build): fix templateCache generation on gulpfile (#1936)

### DIFF
--- a/templates/app/gulpfile.babel(gulp).js
+++ b/templates/app/gulpfile.babel(gulp).js
@@ -558,12 +558,15 @@ gulp.task('build', cb => {
         'wiredep:client',<% if(filters.ts) { %>
         'typings',<% } %>
         [
+            'transpile:client',
+            'transpile:server'
+        ],
+        [
             'build:images',
             'copy:extras',
             'copy:fonts',
             'copy:assets',
             'copy:server',
-            'transpile:server',
             'build:client'
         ],
         cb);
@@ -571,7 +574,7 @@ gulp.task('build', cb => {
 
 gulp.task('clean:dist', () => del([`${paths.dist}/!(.git*|.openshift|Procfile)**`], {dot: true}));
 
-gulp.task('build:client', ['transpile:client', 'styles', 'html', 'constant', 'build:images'], () => {
+gulp.task('build:client', ['styles', 'html', 'constant', 'build:images'], () => {
     var manifest = gulp.src(`${paths.dist}/${clientPath}/assets/rev-manifest.json`);
 
     var appFilter = plugins.filter('**/app.js', {restore: true});


### PR DESCRIPTION
- [x] I have read the [Contributing Documents](https://github.com/DaftMonk/generator-angular-fullstack/blob/master/contributing.md)
- [x] My commit(s) follow the [AngularJS commit message guidelines](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/)
- [x] The generator's tests pass (`generator-angular-fullstack$ npm test`)

Change execution order for gulp tasks 'transpile:client' and 'html' to fix the templateCache generation.

closes #1936