### PR TITLE
Webpack gulp clean up

### DIFF
--- a/templates/app/gulpfile.babel(gulp).js
+++ b/templates/app/gulpfile.babel(gulp).js
@@ -522,13 +522,9 @@ gulp.task('build', cb => {
             'clean:tmp'
         ],
         'inject',
-        [
-            'transpile:client',
-            'transpile:server'
-        ],
+        'transpile:server',
         [
             'build:images',
-            'generate-favicon',
             'typings'
         ],
         [

--- a/templates/app/gulpfile.babel(gulp).js
+++ b/templates/app/gulpfile.babel(gulp).js
@@ -181,41 +181,8 @@ gulp.task('env:prod', () => {
  ********************/
 
 gulp.task('inject', cb => {
-    runSequence(['inject:css'<% if(!filters.css) { %>, 'inject:<%= styleExt %>'<% } %><% if(filters.ts) { %>, 'inject:tsconfig'<% } %>], cb);
-});<% if(filters.ts) { %>
-
-function injectTsConfig(filesGlob, tsconfigPath){
-    let src = gulp.src(filesGlob, {read: false})
-        .pipe(plugins.sort());
-
-    return gulp.src(tsconfigPath)
-        .pipe(plugins.inject(src, {
-            starttag: '"files": [',
-            endtag: ']',
-            transform: (filepath, file, i, length) => {
-                return `"${filepath.substr(1)}"${i + 1 < length ? ',' : ''}`;
-            }
-        }))
-        .pipe(gulp.dest('./'));
-}
-
-gulp.task('inject:tsconfig', () => {
-    return injectTsConfig([
-        `${clientPath}/**/!(*.spec|*.mock).ts`,
-        `!${clientPath}/bower_components/**/*`,
-        `typings/main.d.ts`
-    ],
-    './tsconfig.client.json');
+    runSequence(['inject:css'<% if(!filters.css) { %>, 'inject:<%= styleExt %>'<% } %>], cb);
 });
-
-gulp.task('inject:tsconfigTest', () => {
-    return injectTsConfig([
-        `${clientPath}/**/+(*.spec|*.mock).ts`,
-        `!${clientPath}/bower_components/**/*`,
-        `typings/main.d.ts`
-    ],
-    './tsconfig.client.test.json');
-});<% } %>
 
 gulp.task('inject:css', () => {
     return gulp.src(paths.client.mainView)

--- a/templates/app/gulpfile.babel(gulp).js
+++ b/templates/app/gulpfile.babel(gulp).js
@@ -33,6 +33,7 @@ const paths = {
     client: {
         assets: `${clientPath}/assets/**/*`,
         images: `${clientPath}/assets/images/**/*`,
+        revManifest: `${clientPath}/assets/rev-manifest.json`,
         scripts: [
             `${clientPath}/**/!(*.spec|*.mock).<%= scriptExt %>`,
             `!${clientPath}/bower_components/**/*`<% if(filters.ts) { %>,
@@ -564,7 +565,7 @@ gulp.task('build:images', () => {
         }))
         .pipe(plugins.rev())
         .pipe(gulp.dest(`${paths.dist}/${clientPath}/assets/images`))
-        .pipe(plugins.rev.manifest(`${paths.dist}/${clientPath}/assets/rev-manifest.json`, {
+        .pipe(plugins.rev.manifest(`${paths.dist}/${paths.client.revManifest}`, {
             base: `${paths.dist}/${clientPath}/assets`,
             merge: true
         }))
@@ -573,7 +574,7 @@ gulp.task('build:images', () => {
 
 gulp.task('revReplaceWebpack', function() {
     return gulp.src('dist/client/app.*.js')
-        .pipe(plugins.revReplace({manifest: gulp.src(paths.client.assets.revManifest)}))
+        .pipe(plugins.revReplace({manifest: gulp.src(`${paths.dist}/${paths.client.revManifest}`)}))
         .pipe(gulp.dest('dist/client'));
 });
 

--- a/templates/app/tsconfig.client(ts).json
+++ b/templates/app/tsconfig.client(ts).json
@@ -19,35 +19,5 @@
     "awesomeTypescriptLoaderOptions": {
       "resolveGlobs": true,
       "forkChecker": true
-    },
-    "files": [
-        "client/app/account/account.ts",
-        "client/app/account/login/login.controller.ts",
-        "client/app/account/settings/settings.controller.ts",
-        "client/app/account/signup/signup.controller.ts",
-        "client/app/admin/admin.controller.ts",
-        "client/app/admin/admin.module.ts",
-        "client/app/admin/admin.router.ts",
-        "client/app/app.ts",
-        "client/app/main/main.controller.ts",
-        "client/app/main/main.ts",
-        "client/components/auth/auth.module.ts",
-        "client/components/auth/auth.service.ts",
-        "client/components/auth/interceptor.service.ts",
-        "client/components/auth/router.decorator.ts",
-        "client/components/auth/user.service.ts",
-        "client/components/footer/footer.directive.ts",
-        "client/components/modal/modal.service.ts",
-        "client/components/mongoose-error/mongoose-error.directive.ts",
-        "client/components/navbar/navbar.controller.ts",
-        "client/components/navbar/navbar.directive.ts",
-        "client/components/oauth-buttons/oauth-buttons.controller.ts",
-        "client/components/oauth-buttons/oauth-buttons.directive.ts",
-        "client/components/socket/socket.mock.ts",
-        "client/components/socket/socket.service.ts",
-        "client/components/ui-router/ui-router.mock.ts",
-        "client/components/util/util.module.ts",
-        "client/components/util/util.service.ts",
-        "typings/main.d.ts"
-    ]
+    }
 }

--- a/templates/app/tsconfig.client.test(ts).json
+++ b/templates/app/tsconfig.client.test(ts).json
@@ -8,22 +8,5 @@
     "filesGlob": [
         "client/{app,components}/**/*.{spec,mock}.ts",
         "client/test_typings/**/*.d.ts"
-    ],
-    "files": [
-        "client/app/main/main.controller.spec.ts",
-        "client/components/oauth-buttons/oauth-buttons.controller.spec.ts",
-        "client/components/oauth-buttons/oauth-buttons.directive.spec.ts",
-        "client/components/socket/socket.mock.ts",
-        <%_ if(filters.uirouter) { _%>
-        "client/components/ui-router/ui-router.mock.ts",<% } %>
-        "client/test_typings/angular-protractor/angular-protractor.d.ts",
-        "client/test_typings/selenium-webdriver/selenium-webdriver.d.ts",<% if(filters.mocha) { %>
-        "client/test_typings/mocha/mocha.d.ts",
-        "client/test_typings/chai/chai.d.ts",
-        "client/test_typings/assertion-error/assertion-error.d.ts",
-        "client/test_typings/sinon/sinon.d.ts",
-        "client/test_typings/sinon-chai/sinon-chai.d.ts",<% } %><% if(filters.jasmine) { %>
-        "client/test_typings/jasmine/jasmine.d.ts",<% } %>
-        "client/test_typings/tsd.d.ts"
     ]
 }


### PR DESCRIPTION
So far, two small fixes to get `gulp build` up and running again. Could perhaps do the rest of the gulp clean up mentioned in #1196 here.

Removed tsconfig injection and files in tsconfig's as webpack does not use it.

- [x] I have read the [Contributing Documents](https://github.com/DaftMonk/generator-angular-fullstack/blob/master/contributing.md)
- [x] My commit(s) follow the [AngularJS commit message guidelines](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/)
- [x] The generator's tests pass (`generator-angular-fullstack$ npm test`)