### PR TITLE
fix(authorization): header workaround for IE11

### DIFF
--- a/templates/app/server/auth(auth)/auth.service.js
+++ b/templates/app/server/auth(auth)/auth.service.js
@@ -24,6 +24,10 @@ export function isAuthenticated() {
       if (req.query && req.query.hasOwnProperty('access_token')) {
         req.headers.authorization = 'Bearer ' + req.query.access_token;
       }
+     // IE11 forgets to set Authorization header sometimes. Pull from cookie instead.
+     if (req.query && typeof req.headers.authorization === 'undefined') {
+       req.headers.authorization = 'Bearer ' + req.cookies.token;
+     }
       validateJwt(req, res, next);
     })
     // Attach user to request


### PR DESCRIPTION
- [X] I have read the [Contributing Documents](https://github.com/DaftMonk/generator-angular-fullstack/blob/master/contributing.md)
- [X] My commit(s) follow the [AngularJS commit message guidelines](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/)
- [ ] The generator's tests pass (`generator-angular-fullstack$ npm test`)

use cookie instead so auth succeeds