### PR TITLE
fix(endpoint:controller): wrap saveUpdates in an if(entity) statement

### DIFF
--- a/templates/endpoint/basename.controller.js
+++ b/templates/endpoint/basename.controller.js
@@ -24,13 +24,15 @@ function respondWithResult(res, statusCode) {
 
 function saveUpdates(updates) {
   return function(entity) {
-    <%_ if(filters.mongooseModels) { -%>
-    var updated = _.merge(entity, updates);
-    return updated.save();
-    <%_ } -%>
-    <%_ if(filters.sequelizeModels) { -%>
-    return entity.updateAttributes(updates);
-    <%_ } -%>
+    if (entity) {
+      <%_ if(filters.mongooseModels) { -%>
+      var updated = _.merge(entity, updates);
+      return updated.save();
+      <%_ } -%>
+      <%_ if(filters.sequelizeModels) { -%>
+      return entity.updateAttributes(updates);
+      <%_ } -%>
+    }
   };
 }
 


### PR DESCRIPTION
Regarding issue [#2052](https://github.com/angular-fullstack/generator-angular-fullstack/issues/2052)

Fixes issue in endpoint controller - when `handleEntityNotFound` returns `null` if the entity is not found, it causes `saveUpdates` to throw an error since updated.save() is called on null. This will result in a 500 response when the entity is not found, instead of the expected 404.

Wrapping `saveUpdates` in `if(entity)` will make it return with `undefined` when the entity is `null`, which solves the issue.