### PR TITLE
feat(project): replace livereload with browser-sync

### DIFF
--- a/templates/app/_package.json
+++ b/templates/app/_package.json
@@ -65,6 +65,8 @@
     "babel-core": "^6.6.5",
     "babel-eslint": "^6.0.4",
     "babel-register": "^6.6.5",
+    "browser-sync": "^2.8.0",
+    "bs-fullscreen-message": "^1.0.0",
     <%_ if(filters.flow) { -%>
     "flow-bin": "^0.27.0",
     "babel-plugin-syntax-flow": "^6.8.0",
@@ -92,7 +94,6 @@
     "gulp-inject": "^4.0.0",
     "gulp-istanbul": "~0.10.3",
     "gulp-istanbul-enforcer": "^1.0.3",
-    "gulp-livereload": "^3.8.0",
     "gulp-load-plugins": "^1.0.0-rc.1",
     "gulp-clean-css": "^2.0.6",
     "gulp-mocha": "^2.1.3",
@@ -159,7 +160,6 @@
     <%# END WEBPACK %>
     "through2": "^2.0.1",
     "open": "~0.0.4",
-    "connect-livereload": "^0.5.3",
     "istanbul": "~0.4.1",
     "chai": "^3.2.0",
     "sinon": "^1.16.1",
@@ -182,6 +182,7 @@
     "jasmine-spec-reporter": "^2.4.0",<% } %>
     "phantomjs-prebuilt": "^2.1.4",
     "proxyquire": "^1.0.1",
+    "strip-ansi": "^3.0.1",
     "supertest": "^1.1.0"<% if(filters.ts) { %>,
     "tslint": "^3.5.0",
     "typings": "^0.8.1"<% } %>

--- a/templates/app/gulpfile.babel.js
+++ b/templates/app/gulpfile.babel.js
@@ -229,8 +229,7 @@ gulp.task('webpack:dev', function() {
     return gulp.src(webpackDevConfig.entry.app)
         .pipe(plugins.plumber())
         .pipe(webpack(webpackDevConfig))
-        .pipe(gulp.dest('.tmp'))
-        .pipe(plugins.livereload());
+        .pipe(gulp.dest('.tmp'));
 });
 
 gulp.task('webpack:dist', function() {
@@ -311,7 +310,7 @@ gulp.task('clean:tmp', () => del(['.tmp/**/*'], {dot: true}));
 
 gulp.task('start:client', cb => {
     whenServerReady(() => {
-        open('http://localhost:' + config.port);
+        open('http://localhost:' + config.browserSyncPort);
         cb();
     });
 });
@@ -347,12 +346,9 @@ gulp.task('start:server:debug', () => {
 gulp.task('watch', () => {
     var testFiles = _.union(paths.client.test, paths.server.test.unit, paths.server.test.integration);
 
-    plugins.livereload.listen();
-
     plugins.watch(_.union(paths.server.scripts, testFiles))
         .pipe(plugins.plumber())
-        .pipe(lintServerScripts())
-        .pipe(plugins.livereload());
+        .pipe(lintServerScripts());
 
     plugins.watch(_.union(paths.server.test.unit, paths.server.test.integration))
         .pipe(plugins.plumber())

--- a/templates/app/server/config/environment/index.js
+++ b/templates/app/server/config/environment/index.js
@@ -19,6 +19,9 @@ var all = {
   // Root path of server
   root: path.normalize(`${__dirname}/../../..`),
 
+  // Browser-sync port
+  browserSyncPort: process.env.BROWSER_SYNC_PORT || 3000,
+
   // Server port
   port: process.env.PORT || <%= devPort %>,
 


### PR DESCRIPTION
- [x] I have read the [Contributing Documents](https://github.com/DaftMonk/generator-angular-fullstack/blob/master/contributing.md)
- [x] My commit(s) follow the [AngularJS commit message guidelines](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/)
- [x] The generator's tests pass (`generator-angular-fullstack$ npm test`)

Closes #1955.

As the title says, this commit replaces the `livereload` functionality with browser-sync. The greatest benefit this gives is the possibility to get multiple windows on multiple devices to update for each change. Additionally granting scroll, click and form input mirroring. Thus essentially enabling the testing of multiple devices at a time.

The only controversial change I can think of is likely the switch to a separate port when in development while the earlier default port is used to proxy both static content and the API.

That new port is hard-coded in the config file (next to the `devPort`) to the browser-sync default of 3000.  Figure two changes could me made:

1. Add some kind of customization similar to `devPort` to the browser-sync-port
2. Change the browser-sync port to the generator's old default of 9000, though that would also require changing the server development port to some other port.

An alternative implementation would make use of either the `browser-sync-spa` plugin or directly use its dependency `connect-history-api-fallback`. I opted out from that strategy because I felt this proxy-reliant solution was more straight-forward and more suitable given our fullstack + webpack project.