### PR TITLE
fix(webpack): windows compatible webpack config entry point path

### DIFF
--- a/templates/app/webpack.make.js
+++ b/templates/app/webpack.make.js
@@ -38,8 +38,8 @@ module.exports = function makeWebpackConfig(options) {
         config.entry = {};
     } else {
         config.entry = {
-            app: './client/app/app.<%= scriptExt %>',
-            polyfills: './client/polyfills.<%= scriptExt %>',
+            app: path.join(__dirname, '/client/app/app.<%= scriptExt %>'),
+            polyfills: path.join(__dirname, '/client/polyfills.<%= scriptExt %>'),
             vendor: [
                 'angular',
                 'angular-animate',


### PR DESCRIPTION
- [x] I have read the [Contributing Documents](https://github.com/DaftMonk/generator-angular-fullstack/blob/master/contributing.md)
- [x] My commit(s) follow the [AngularJS commit message guidelines](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/)
- [x] The generator's tests pass (`generator-angular-fullstack$ npm test`)

fixes (#2091)
