### PR TITLE
fix(gulpfile): gulp-filter@4.0.0 need "dot:true" option

### DIFF
--- a/templates/app/gulpfile.babel(gulp).js
+++ b/templates/app/gulpfile.babel(gulp).js
@@ -577,10 +577,10 @@ gulp.task('clean:dist', () => del([`${paths.dist}/!(.git*|.openshift|Procfile)**
 gulp.task('build:client', ['styles', 'html', 'constant', 'build:images'], () => {
     var manifest = gulp.src(`${paths.dist}/${clientPath}/assets/rev-manifest.json`);
 
-    var appFilter = plugins.filter('**/app.js', {restore: true});
-    var jsFilter = plugins.filter('**/*.js', {restore: true});
-    var cssFilter = plugins.filter('**/*.css', {restore: true});
-    var htmlBlock = plugins.filter(['**/*.!(html)'], {restore: true});
+    var appFilter = plugins.filter('**/app.js', {restore: true, dot: true});
+    var jsFilter = plugins.filter('**/*.js', {restore: true, dot: true});
+    var cssFilter = plugins.filter('**/*.css', {restore: true, dot: true});
+    var htmlBlock = plugins.filter(['**/*.!(html)'], {restore: true, dot: true});
 
     return gulp.src(paths.client.mainView)
         .pipe(plugins.useref())


### PR DESCRIPTION
when gulp build, gulp-filter@4.0.0 will miss file path start with dot like ".tmp/app/app.js", that cause some files not uglify or rev. add option "dot:true" resolve this problem

https://github.com/angular-fullstack/generator-angular-fullstack/issues/2146