### PR TITLE
fix(webpack): fix webpack vendor import

### DIFF
--- a/templates/app/webpack.make.js
+++ b/templates/app/webpack.make.js
@@ -49,7 +49,8 @@ module.exports = function makeWebpackConfig(options) {
                 <%_ if(filters.ngroute) { _%>
                 'angular-route',<% } %>
                 'angular-sanitize',
-                'angular-socket-io',
+                <%_ if(filters.socketio) { _%>
+                'angular-socket-io',<% } %>
                 'angular-ui-bootstrap',
                 <%_ if(filters.uirouter) { _%>
                 'angular-ui-router',<% } %>


### PR DESCRIPTION
exclude angular-socket-io when user doesn't select socket.io

fixes #2172