### PR TITLE
Changed port variable to capital letters so heroku recognize it

### DIFF
--- a/templates/app/server/config/environment/production.js
+++ b/templates/app/server/config/environment/production.js
@@ -11,7 +11,7 @@ module.exports = {
 
   // Server port
   port: process.env.OPENSHIFT_NODEJS_PORT
-    || process.env.port
+    || process.env.PORT
     || <%= prodPort %><% if(filters.mongoose) { %>,
 
   // MongoDB connection options


### PR DESCRIPTION
- [x] I have read the [Contributing Documents](https://github.com/DaftMonk/generator-angular-fullstack/blob/master/contributing.md)
- [x] My commit(s) follow the [AngularJS commit message guidelines](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/)
- [x] The generator's tests pass (`generator-angular-fullstack$ npm test`)

fix(heroku): Changed port variable to capital letters so heroku recognize it

Heroku uses process.env.PORT with capital letters.