### PR TITLE
Copy bootstrap-sass-official fonts when building

### DIFF
--- a/templates/app/gulpfile.babel.js
+++ b/templates/app/gulpfile.babel.js
@@ -560,12 +560,12 @@ function flatten() {
     });
 }
 gulp.task('copy:fonts:dev', () => {
-    return gulp.src('node_modules/{bootstrap,font-awesome}/fonts/*')
+    return gulp.src('node_modules/{bootstrap,bootstrap-sass-official/vendor/assets,font-awesome}/fonts/*')
         .pipe(flatten())
         .pipe(gulp.dest(`${clientPath}/assets/fonts`));
 });
 gulp.task('copy:fonts:dist', () => {
-    return gulp.src('node_modules/{bootstrap,font-awesome}/fonts/*')
+    return gulp.src('node_modules/{bootstrap,bootstrap-sass-official/vendor/assets,font-awesome}/fonts/*')
         .pipe(flatten())
         .pipe(gulp.dest(`${paths.dist}/${clientPath}/assets/fonts`));
 });


### PR DESCRIPTION
- [x] I have read the [Contributing Documents](https://github.com/DaftMonk/generator-angular-fullstack/blob/master/contributing.md)
- [x] My commit(s) follow the [AngularJS commit message guidelines](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/)
- [x] The generator's tests pass (`generator-angular-fullstack$ npm test`)
