### PR TITLE
docs(readme): Add a more explicit advice for compiling native add-ons

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,9 @@ Install `yo`, `gulp-cli`, and `generator-angular-fullstack`:
 ```
 npm install -g yo gulp-cli generator-angular-fullstack
 ```
+__Please note__: If you run into trouble compiling native add-ons during the installation, follow [`node-gyp`](https://github.com/nodejs/node-gyp)'s short guide on [required compilation tools](https://github.com/nodejs/node-gyp#installation).
+
+---
 
 Run `yo angular-fullstack`
 ```
@@ -35,7 +38,6 @@ yo angular-fullstack
 
 * MongoDB - Download and Install [MongoDB](https://www.mongodb.com/download-center#community) - If you plan on scaffolding your project with mongoose, you'll need mongoDB to be installed and have the `mongod` process running.
 * The project's JavaScript is written in ECMAScript 2015. If you're unfamiliar with the latest changes to the specification for JavaScript, check out http://es6-features.org/
-* [`node-gyp`](https://github.com/nodejs/node-gyp) - You'll likely need to be able to use `node-gyp`, Node's tool for compiling native add-ons (for things like database drivers). See its [Installation section](https://github.com/nodejs/node-gyp#installation) for more instructions.
 
 ## Supported Configurations
 


### PR DESCRIPTION
- [x] I have read the [Contributing Documents](https://github.com/DaftMonk/generator-angular-fullstack/blob/master/contributing.md)
- [give me a break] My commit(s) follow the [AngularJS commit message guidelines](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/)
- [ ] The generator's tests pass (`generator-angular-fullstack$ npm test`)

The node-gyp prerequisite was not making it clear that it is related to the npm install part of the Usage guide.