### PR TITLE
chore(deps): update istanbul to 0.4.5

### DIFF
--- a/templates/app/_package.json
+++ b/templates/app/_package.json
@@ -143,7 +143,7 @@
     <%# END WEBPACK %>
     "through2": "^2.0.1",
     "open": "~0.0.4",
-    "istanbul": "1.1.0-alpha.1",
+    "istanbul": "0.4.5",
     "chai": "^3.2.0",
     "sinon": "^1.16.1",
     "chai-as-promised": "^5.1.0",


### PR DESCRIPTION
- [x] I have read the [Contributing Documents](https://github.com/DaftMonk/generator-angular-fullstack/blob/master/contributing.md)
- [x] My commit(s) follow the [AngularJS commit message guidelines](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/)
- [x] The generator's tests pass (`generator-angular-fullstack$ npm test`)

resolves one case of minimatch security issue

istanbul@1.1.0-alpha.1 was dep on minimatch@2.0.10 which has RegExp DoS issue