### PR TITLE
fix(server:auth:local): sessions fix

### DIFF
--- a/templates/app/server/auth(auth)/local/index.js
+++ b/templates/app/server/auth(auth)/local/index.js
@@ -16,8 +16,14 @@ router.post('/', function(req, res, next) {
       return res.status(404).json({message: 'Something went wrong, please try again.'});
     }
 
-    var token = signToken(user._id, user.role);
-    res.json({ token });
+    req.login(user, err => {
+      if(err) {
+        return next(err);
+      }
+
+      var token = signToken(user._id, user.role);
+      return res.json({ token });
+    });
   })(req, res, next);
 });
 


### PR DESCRIPTION
- [x] I have read the [Contributing Documents](https://github.com/DaftMonk/generator-angular-fullstack/blob/master/contributing.md)
- [x] My commit(s) follow the [AngularJS commit message guidelines](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/)
- [ ] The generator's tests pass (`generator-angular-fullstack$ npm test`)

call "req.login" manually in order to use sessions.
because custom callback used with "passport.authenticate"
see - http://passportjs.org/docs#custom-callback