### PR TITLE
fix(webpack:css): disable css-loader sourceMap option

### DIFF
--- a/templates/app/webpack.make.js
+++ b/templates/app/webpack.make.js
@@ -211,7 +211,7 @@ module.exports = function makeWebpackConfig(options) {
                 //
                 // Reference: https://github.com/webpack/style-loader
                 // Use style-loader in development for hot-loading
-                ? ExtractTextPlugin.extract('style', 'css?sourceMap!postcss')
+                ? ExtractTextPlugin.extract('style', 'css!postcss')
                 // Reference: https://github.com/webpack/null-loader
                 // Skip loading css in test mode
                 : 'null'


### PR DESCRIPTION
fixes #2188