### PR TITLE
Updated IIS.md

### DIFF
--- a/docs/Examples/IIS.md
+++ b/docs/Examples/IIS.md
@@ -118,15 +118,12 @@ The below steps assume you have purchased a domain and have pointed your DNS to 
 </configuration>
 ```
 
-**Setup IIS**
+**Setup IIS (if new build in IIS)**
   - Open IIS Manager (*Start > Type 'IIS Manager'*)
   - Create your new site (*Expand Server > Right click sites > 'Add Websites'*)
   - Enter your site's name
   - Enter the directory path to your `client/` folder (*`C:\example\dist\client\`*)
   - Enter your hostname (*Your a-record*)
   - Leave all other defaults and click 'Ok'
-
-**Start your server**
-  - Run `gulp serve:dist`
 
 # Congratulations, you did it! Now go code something awesome!


### PR DESCRIPTION
There is no reason to run ```gulp serve:dist``` after you build the first time. This will clear your web.config from your `client` folder.

- [x] I have read the [Contributing Documents](https://github.com/DaftMonk/generator-angular-fullstack/blob/master/contributing.md)
- [x] My commit(s) follow the [AngularJS commit message guidelines](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/)
- [x] The generator's tests pass (`generator-angular-fullstack$ npm test`)
