### PR TITLE
fix(authorization): fix typo in cookies check before setting token in…

### DIFF
--- a/templates/app/server/auth(auth)/auth.service.js
+++ b/templates/app/server/auth(auth)/auth.service.js
@@ -22,11 +22,18 @@ export function isAuthenticated() {
       if (req.query && req.query.hasOwnProperty('access_token')) {
         req.headers.authorization = 'Bearer ' + req.query.access_token;
       }
-     // IE11 forgets to set Authorization header sometimes. Pull from cookie instead.
-     if (req.query && typeof req.headers.authorization === 'undefined') {
-       req.headers.authorization = 'Bearer ' + req.cookies.token;
-     }
+      // IE11 forgets to set Authorization header sometimes. Pull from cookie instead.
+      if (req.cookies && req.cookies.hasOwnProperty('token') && typeof req.headers.authorization === 'undefined') {
+        req.headers.authorization = 'Bearer ' + req.cookies.token;
+      }
       validateJwt(req, res, next);
+    })
+    // UnauthorizedError handler.
+    .use(function(err, req, res, next) {
+      if(err.name === 'UnauthorizedError') {
+        res.status(err.status).send(err.message);
+      }
+      next();
     })
     // Attach user to request
     .use(function(req, res, next) {


### PR DESCRIPTION
fix(authorization): fix typo in cookies check before setting token in auth header

When setting the Authorization header from cookies,
the previous behavior wasn't checking if the cookie was actually set properly.
This is inconsequential for the behavior of the app because the middleware will
still throw an Unauthorized response, but might be confusing for developers
inspecting the generated code.

Closes #2475

- [x] I have read the [Contributing Documents](https://github.com/DaftMonk/generator-angular-fullstack/blob/master/contributing.md)
- [x] My commit(s) follow the [AngularJS commit message guidelines](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/)
- [ ] The generator's tests pass (`generator-angular-fullstack$ npm test`)

Besides closing the issue, I added an Unauthorized middleware handler right next to the `validateJwt` one. I think having it in the generator aswell could be beneficial for developers, so newbies have a visible clear place where to put their custom unauthorization logic.

P.S.: Just as a side note, in my own apps, I always use  the `http-status-codes` npm package all throughout the codebase. This eliminates the magic numbers representing the codes and looks much prettier. Not everyone knows them by memory and shouldn't have to at this point. I'm willing to submit a PR to change this in the templates if the suggestion is accepted.

