### PR TITLE
fix (app): prevent excess sync() calls during db seed

### DIFF
--- a/templates/app/server/app.js
+++ b/templates/app/server/app.js
@@ -10,6 +10,7 @@ mongoose.Promise = require('bluebird');<% } %><% if (filters.sequelize) { %>
 import sqldb from './sqldb';<% } %>
 import config from './config/environment';
 import http from 'http';
+<% if(filters.models) { %>import seedDatabaseIfNeeded from './config/seed';<% } %>
 <% if (filters.mongoose) { %>
 // Connect to MongoDB
 mongoose.connect(config.mongo.uri, config.mongo.options);
@@ -17,11 +18,6 @@ mongoose.connection.on('error', function(err) {
   console.error('MongoDB connection error: ' + err);
   process.exit(-1); // eslint-disable-line no-process-exit
 });
-<% } %><% if(filters.models) { %>
-// Populate databases with sample data
-if(config.seedDB) {
-  require('./config/seed');
-}
 <% } %>
 // Setup server
 var app = express();
@@ -43,6 +39,7 @@ function startServer() {
 <% if(filters.sequelize) { %>
 sqldb.sequelize.sync()
   .then(startServer)
+<% if(filters.models) { %>  .then(seedDatabaseIfNeeded)<% } %>
   .catch(function(err) {
     console.log('Server failed to start due to error: %s', err);
   });

--- a/templates/app/server/app.js
+++ b/templates/app/server/app.js
@@ -44,6 +44,7 @@ sqldb.sequelize.sync()
     console.log('Server failed to start due to error: %s', err);
   });
 <% } else { %>
+seedDatabaseIfNeeded();
 setImmediate(startServer);
 <% } %>
 // Expose app

--- a/templates/app/server/app.js
+++ b/templates/app/server/app.js
@@ -37,14 +37,14 @@ function startServer() {
   });
 }
 <% if(filters.sequelize) { %>
-sqldb.sequelize.sync()
+sqldb.sequelize.sync()<% if(filters.models) { %>
+  .then(seedDatabaseIfNeeded)<% } %>
   .then(startServer)
-<% if(filters.models) { %>  .then(seedDatabaseIfNeeded)<% } %>
   .catch(function(err) {
     console.log('Server failed to start due to error: %s', err);
   });
-<% } else { %>
-seedDatabaseIfNeeded();
+<% } else { %><% if(filters.models) { %>
+seedDatabaseIfNeeded();<% } %>
 setImmediate(startServer);
 <% } %>
 // Expose app

--- a/templates/app/server/config/seed(models).js
+++ b/templates/app/server/config/seed(models).js
@@ -6,67 +6,70 @@
 'use strict';<% if (filters.mongooseModels) { %>
 import Thing from '../api/thing/thing.model';<% if (filters.auth) { %>
 import User from '../api/user/user.model';<% } %><% } %><% if (filters.sequelizeModels) { %>
-import sqldb from '../sqldb';
-var Thing = sqldb.Thing;<% if (filters.auth) { %>
-var User = sqldb.User;<% } %><% } %>
+import sqldb from '../sqldb';<% } %>
+import config from './environment/';
 
-<% if (filters.mongooseModels) { %>Thing.find({}).remove()<% }
-   if (filters.sequelizeModels) { %>Thing.sync()
-  .then(() => {
-    return Thing.destroy({ where: {} });
-  })<% } %>
-  .then(() => {
-    <% if (filters.mongooseModels) { %>Thing.create({<% }
-       if (filters.sequelizeModels) { %>Thing.bulkCreate([{<% } %>
-      name: 'Development Tools',
-      info: 'Integration with popular tools such as Webpack, Gulp, Babel, TypeScript, Karma, '
-            + 'Mocha, ESLint, Node Inspector, Livereload, Protractor, Pug, '
-            + 'Stylus, Sass, and Less.'
-    }, {
-      name: 'Server and Client integration',
-      info: 'Built with a powerful and fun stack: MongoDB, Express, '
-            + 'AngularJS, and Node.'
-    }, {
-      name: 'Smart Build System',
-      info: 'Build system ignores `spec` files, allowing you to keep '
-            + 'tests alongside code. Automatic injection of scripts and '
-            + 'styles into your index.html'
-    }, {
-      name: 'Modular Structure',
-      info: 'Best practice client and server structures allow for more '
-            + 'code reusability and maximum scalability'
-    }, {
-      name: 'Optimized Build',
-      info: 'Build process packs up your templates as a single JavaScript '
-            + 'payload, minifies your scripts/css/images, and rewrites asset '
-            + 'names for caching.'
-    }, {
-      name: 'Deployment Ready',
-      info: 'Easily deploy your app to Heroku or Openshift with the heroku '
-            + 'and openshift subgenerators'
-    <% if (filters.mongooseModels) { %>});<% }
-       if (filters.sequelizeModels) { %>}]);<% } %>
-  });
+export default function seedDatabaseIfNeeded() {
+  if(config.seedDB) {
+    <% if (filters.sequelizeModels) { %>let Thing = sqldb.Thing;<% if (filters.auth) { %>
+    let User = sqldb.User;<% } %><% } %>
+
+    <% if (filters.mongooseModels) { %>Thing.find({}).remove()<% }
+       if (filters.sequelizeModels) { %>return Thing.destroy({ where: {} })<% } %>
+      .then(() => {
+        <% if (filters.mongooseModels) { %>Thing.create({<% }
+           if (filters.sequelizeModels) { %>return Thing.bulkCreate([{<% } %>
+          name: 'Development Tools',
+          info: 'Integration with popular tools such as Webpack, Gulp, Babel, TypeScript, Karma, '
+                + 'Mocha, ESLint, Node Inspector, Livereload, Protractor, Pug, '
+                + 'Stylus, Sass, and Less.'
+        }, {
+          name: 'Server and Client integration',
+          info: 'Built with a powerful and fun stack: MongoDB, Express, '
+                + 'AngularJS, and Node.'
+        }, {
+          name: 'Smart Build System',
+          info: 'Build system ignores `spec` files, allowing you to keep '
+                + 'tests alongside code. Automatic injection of scripts and '
+                + 'styles into your index.html'
+        }, {
+          name: 'Modular Structure',
+          info: 'Best practice client and server structures allow for more '
+                + 'code reusability and maximum scalability'
+        }, {
+          name: 'Optimized Build',
+          info: 'Build process packs up your templates as a single JavaScript '
+                + 'payload, minifies your scripts/css/images, and rewrites asset '
+                + 'names for caching.'
+        }, {
+          name: 'Deployment Ready',
+          info: 'Easily deploy your app to Heroku or Openshift with the heroku '
+                + 'and openshift subgenerators'
+        <% if (filters.mongooseModels) { %>});<% }
+         if (filters.sequelizeModels) { %>}]);<% } %>
+    })
+    .then(() => console.log('finished populating things'))
+    .catch(err => console.log('error populating things', err));
 <% if (filters.auth) { %>
-<% if (filters.mongooseModels) { %>User.find({}).remove()<% }
-   if (filters.sequelizeModels) { %>User.sync()
-  .then(() => User.destroy({ where: {} }))<% } %>
-  .then(() => {
-    <% if (filters.mongooseModels) { %>User.create({<% }
-       if (filters.sequelizeModels) { %>User.bulkCreate([{<% } %>
-      provider: 'local',
-      name: 'Test User',
-      email: 'test@example.com',
-      password: 'test'
-    }, {
-      provider: 'local',
-      role: 'admin',
-      name: 'Admin',
-      email: 'admin@example.com',
-      password: 'admin'
-    <% if (filters.mongooseModels) { %>})<% }
-       if (filters.sequelizeModels) { %>}])<% } %>
-    .then(() => {
-      console.log('finished populating users');
+    <% if (filters.mongooseModels) { %>User.find({}).remove()<% }
+     if (filters.sequelizeModels) { %>User.destroy({ where: {} })<% } %>
+      .then(() => {
+        <% if (filters.mongooseModels) { %>User.create({<% }
+         if (filters.sequelizeModels) { %>return User.bulkCreate([{<% } %>
+          provider: 'local',
+          name: 'Test User',
+          email: 'test@example.com',
+          password: 'test'
+        }, {
+          provider: 'local',
+          role: 'admin',
+          name: 'Admin',
+          email: 'admin@example.com',
+          password: 'admin'
+        <% if (filters.mongooseModels) { %>})<% }
+         if (filters.sequelizeModels) { %>}])<% } %>
+        .then(() => console.log('finished populating users'))
+        .catch(err => console.log('error populating users', err));<% } %>
     });
-  });<% } %>
+  }
+}


### PR DESCRIPTION
Previously, .sync() was being called once in server/config/seed.js and once during sqldb.sequelize.sync() in server/app.js. As a result, duplicate queries were being sent to the database if the tables needed to be defined causing an error when it tries to define constraints a second time (like for an identity column).

Seed.js is wrapped in a function and contains the conditional to determine whether to seed the database. This makes it easy to include in the promise chain under sqldb.sequelize.sync().

- [x] I have read the [Contributing Documents](https://github.com/DaftMonk/generator-angular-fullstack/blob/master/contributing.md)
- [x] My commit(s) follow the [AngularJS commit message guidelines](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/)
- [x] The generator's tests pass (`generator-angular-fullstack$ npm test`)
