### PR TITLE
fix(seed): remove return from Thing.destroy

### DIFF
--- a/templates/app/server/config/seed(models).js
+++ b/templates/app/server/config/seed(models).js
@@ -15,7 +15,7 @@ export default function seedDatabaseIfNeeded() {
     let User = sqldb.User;<% } %><% } %>
 
     <% if (filters.mongooseModels) { %>Thing.find({}).remove()<% }
-       if (filters.sequelizeModels) { %>return Thing.destroy({ where: {} })<% } %>
+       if (filters.sequelizeModels) { %>Thing.destroy({ where: {} })<% } %>
       .then(() => {
         <% if (filters.mongooseModels) { %>Thing.create({<% }
            if (filters.sequelizeModels) { %>return Thing.bulkCreate([{<% } %>


### PR DESCRIPTION
The return on Thing.destroy was preventing the creation of the users when filters.sequelizeModels and filters.auth were both true. A better way to handle them would be to import sequelize then wrap the creation of things and users in Sequelize.Promise.all. That would prevent the warnings for unhandled promises. Just wanted to get the bug fixed for now. Can work on trying to make it prettier later.

- [x] I have read the [Contributing Documents](https://github.com/DaftMonk/generator-angular-fullstack/blob/master/contributing.md)
- [x] My commit(s) follow the [AngularJS commit message guidelines](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/)
- [x] The generator's tests pass (`generator-angular-fullstack$ npm test`)
