### PR TITLE
chore(package): remove gulp-node-inspector

### DIFF
--- a/templates/app/_package.json
+++ b/templates/app/_package.json
@@ -92,7 +92,6 @@
     "gulp-istanbul-enforcer": "^1.0.3",
     "gulp-load-plugins": "^1.0.0-rc.1",
     "gulp-mocha": "^2.1.3",
-    "gulp-node-inspector": "^0.1.0",
     "gulp-plumber": "^1.0.1",
     "gulp-protractor": "^3.0.0",
     "gulp-rev": "^7.0.0",

--- a/templates/app/gulpfile.babel.js
+++ b/templates/app/gulpfile.babel.js
@@ -331,17 +331,11 @@ gulp.task('start:server:prod', () => {
         .on('log', onServerLog);
 });
 
-gulp.task('start:inspector', () => {
-    gulp.src([])
-        .pipe(plugins.nodeInspector({
-          debugPort: <%= debugPort %>
-        }));
-});
-
 gulp.task('start:server:debug', () => {
     process.env.NODE_ENV = process.env.NODE_ENV || 'development';
     config = require(`./${serverPath}/config/environment`);
-    nodemon(`-w ${serverPath} --debug=<%= debugPort %> --debug-brk ${serverPath}`)
+    // nodemon(`-w ${serverPath} --debug=<%= debugPort %> --debug-brk ${serverPath}`)
+    nodemon(`-w ${serverPath} --inspect --debug-brk ${serverPath}`)
         .on('log', onServerLog);
 });
 
@@ -385,7 +379,6 @@ gulp.task('serve:debug', cb => {
             'typings'<% } %>
         ],
         'webpack:dev',
-        'start:inspector',
         ['start:server:debug', 'start:client'],
         'watch',
         cb


### PR DESCRIPTION
use --inspect instead

- [x] I have read the [Contributing Documents](https://github.com/DaftMonk/generator-angular-fullstack/blob/master/contributing.md)
- [x] My commit(s) follow the [AngularJS commit message guidelines](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/)
- [x] The generator's tests pass (`generator-angular-fullstack$ npm test`)
