### PR TITLE
Resolve all Warnings and Deprecated Messages with Default Configuration.

### DIFF
--- a/templates/app/.eslintrc
+++ b/templates/app/.eslintrc
@@ -82,7 +82,7 @@
         "no-octal-escape": 0,                                       //disallow use of octal escape sequences in string literals, such as var foo = "Copyright \251";
         "no-octal": 0,                                              //disallow use of octal literals
         "no-param-reassign": 0,                                     //disallow reassignment of function parameters
-        "no-process-env": 0,                                        //allow use of process.env
+        "no-process-env": 0,                                        //disallow use of process.env
         "no-proto": 2,                                              //disallow usage of __proto__ property
         "no-redeclare": 2,                                          //disallow declaring the same variable more than once
         "no-return-assign": 2,                                      //disallow use of assignment in return statement

--- a/templates/app/.eslintrc
+++ b/templates/app/.eslintrc
@@ -82,7 +82,7 @@
         "no-octal-escape": 0,                                       //disallow use of octal escape sequences in string literals, such as var foo = "Copyright \251";
         "no-octal": 0,                                              //disallow use of octal literals
         "no-param-reassign": 0,                                     //disallow reassignment of function parameters
-        "no-process-env": 1,                                        //disallow use of process.env
+        "no-process-env": 0,                                        //allow use of process.env
         "no-proto": 2,                                              //disallow usage of __proto__ property
         "no-redeclare": 2,                                          //disallow declaring the same variable more than once
         "no-return-assign": 2,                                      //disallow use of assignment in return statement

--- a/templates/app/client/app/app.js
+++ b/templates/app/client/app/app.js
@@ -14,8 +14,7 @@ import uiRouter from 'angular-ui-router';<% } %>
 <%_ if(filters.uibootstrap) { _%>
 import uiBootstrap from 'angular-ui-bootstrap';<% } %>
 <%_ if(filters.auth) { _%>
-// eslint-disable-next-line no-unused-vars
-import ngValidationMatch from 'angular-validation-match';
+import 'angular-validation-match';
 <% } %>
 
 

--- a/templates/app/client/app/app.js
+++ b/templates/app/client/app/app.js
@@ -13,8 +13,8 @@ const ngRoute = require('angular-route');<% } %>
 import uiRouter from 'angular-ui-router';<% } %>
 <%_ if(filters.uibootstrap) { _%>
 import uiBootstrap from 'angular-ui-bootstrap';<% } %>
-// import ngMessages from 'angular-messages';
 <%_ if(filters.auth) { _%>
+// eslint-disable-next-line no-unused-vars
 import ngValidationMatch from 'angular-validation-match';
 <% } %>
 

--- a/templates/app/client/components/auth(auth)/auth.service.js
+++ b/templates/app/client/components/auth(auth)/auth.service.js
@@ -1,3 +1,4 @@
+/*global _*/
 'use strict';
 // @flow
 class _User {
@@ -185,9 +186,8 @@ export function AuthService($location, $http, $cookies, $q, appConfig, Util, Use
       * @param  {Function|*} callback - optional, function(is)
       * @return {Bool|Promise}
       */
-    isAdmin() {
-      return Auth.hasRole
-        .apply(Auth, [].concat.apply(['admin'], arguments));
+    isAdmin(...args) {
+      return Auth.hasRole(...Reflect.apply([].concat, ['admin'], args));
     },
 
      /**
@@ -196,6 +196,7 @@ export function AuthService($location, $http, $cookies, $q, appConfig, Util, Use
       * @return {Bool}
       */
     isAdminSync() {
+      // eslint-disable-next-line no-sync
       return Auth.hasRoleSync('admin');
     },
 

--- a/templates/app/client/components/auth(auth)/auth.service.js
+++ b/templates/app/client/components/auth(auth)/auth.service.js
@@ -1,5 +1,7 @@
-/*global _*/
 'use strict';
+
+import _ from 'lodash';
+
 // @flow
 class _User {
   _id: string = '';

--- a/templates/app/client/components/modal(uibootstrap)/modal.service.js
+++ b/templates/app/client/components/modal(uibootstrap)/modal.service.js
@@ -37,9 +37,9 @@ export function Modal($rootScope, $uibModal) {
          * @param  {String} name   - name or info to show on modal
          * @param  {All}           - any additional args are passed straight to del callback
          */
-        return function() {
-          var args = Array.prototype.slice.call(arguments);
-          var name = args.shift();
+        return function(...args) {
+          var slicedArgs = Reflect.apply(Array.prototype.slice, args);
+          var name = slicedArgs.shift();
           var deleteModal;
 
           deleteModal = openModal({
@@ -64,7 +64,7 @@ export function Modal($rootScope, $uibModal) {
           }, 'modal-danger');
 
           deleteModal.result.then(function(event) {
-            del.apply(event, args);
+            Reflect.apply(del, event, slicedArgs);
           });
         };
       }

--- a/templates/app/server/api/user(auth)/user.model(mongooseModels).js
+++ b/templates/app/server/api/user(auth)/user.model(mongooseModels).js
@@ -197,14 +197,16 @@ UserSchema.methods = {
    * @return {String}
    * @api public
    */
-  makeSalt(byteSize, callback) {
-    var defaultByteSize = 16;
+  makeSalt(...args) {
+    let byteSize;
+    let callback;
+    let defaultByteSize = 16;
 
-    if(typeof arguments[0] === 'function') {
-      callback = arguments[0];
+    if(typeof args[0] === 'function') {
+      callback = args[0];
       byteSize = defaultByteSize;
-    } else if(typeof arguments[1] === 'function') {
-      callback = arguments[1];
+    } else if(typeof args[1] === 'function') {
+      callback = args[1];
     } else {
       throw new Error('Missing Callback');
     }
@@ -244,6 +246,7 @@ UserSchema.methods = {
     var salt = new Buffer(this.salt, 'base64');
 
     if(!callback) {
+      // eslint-disable-next-line no-sync
       return crypto.pbkdf2Sync(password, salt, defaultIterations, defaultKeyLength)
         .toString('base64');
     }

--- a/templates/app/server/api/user(auth)/user.model(mongooseModels).js
+++ b/templates/app/server/api/user(auth)/user.model(mongooseModels).js
@@ -99,10 +99,10 @@ UserSchema
 // Validate email is not taken
 UserSchema
   .path('email')
-  .validate(function(value, respond) {
+  .validate(function(value) {
     <%_ if(filters.oauth) { -%>
     if(authTypes.indexOf(this.provider) !== -1) {
-      return respond(true);
+      return true;
     }
 
     <%_ } -%>
@@ -110,11 +110,11 @@ UserSchema
       .then(user => {
         if(user) {
           if(this.id === user.id) {
-            return respond(true);
+            return true;
           }
-          return respond(false);
+          return false;
         }
-        return respond(true);
+        return true;
       })
       .catch(function(err) {
         throw err;

--- a/templates/app/server/api/user(auth)/user.model(mongooseModels).js
+++ b/templates/app/server/api/user(auth)/user.model(mongooseModels).js
@@ -247,17 +247,19 @@ UserSchema.methods = {
 
     if(!callback) {
       // eslint-disable-next-line no-sync
-      return crypto.pbkdf2Sync(password, salt, defaultIterations, defaultKeyLength)
+      return crypto.pbkdf2Sync(password, salt, defaultIterations,
+          defaultKeyLength, 'sha1')
         .toString('base64');
     }
 
-    return crypto.pbkdf2(password, salt, defaultIterations, defaultKeyLength, (err, key) => {
-      if(err) {
-        return callback(err);
-      } else {
-        return callback(null, key.toString('base64'));
-      }
-    });
+    return crypto.pbkdf2(password, salt, defaultIterations, defaultKeyLength,
+      'sha1', (err, key) => {
+        if(err) {
+          return callback(err);
+        } else {
+          return callback(null, key.toString('base64'));
+        }
+      });
   }
 };
 

--- a/templates/app/server/api/user(auth)/user.model(sequelizeModels).js
+++ b/templates/app/server/api/user(auth)/user.model(sequelizeModels).js
@@ -135,8 +135,10 @@ export default function(sequelize, DataTypes) {
        * @return {String}
        * @api public
        */
-      makeSalt(byteSize, callback) {
-        var defaultByteSize = 16;
+      makeSalt(...args) {
+        let byteSize;
+        let callback;
+        let defaultByteSize = 16;
 
         if(typeof arguments[0] === 'function') {
           callback = arguments[0];
@@ -177,6 +179,7 @@ export default function(sequelize, DataTypes) {
         var salt = new Buffer(this.salt, 'base64');
 
         if(!callback) {
+          // eslint-disable-next-line no-sync
           return crypto.pbkdf2Sync(password, salt, defaultIterations, defaultKeyLength)
                        .toString('base64');
         }

--- a/templates/app/server/config/seed(models).js
+++ b/templates/app/server/config/seed(models).js
@@ -17,7 +17,7 @@ export default function seedDatabaseIfNeeded() {
     <% if (filters.mongooseModels) { %>Thing.find({}).remove()<% }
        if (filters.sequelizeModels) { %>return Thing.destroy({ where: {} })<% } %>
       .then(() => {
-        <% if (filters.mongooseModels) { %>Thing.create({<% }
+        <% if (filters.mongooseModels) { %>return Thing.create({<% }
            if (filters.sequelizeModels) { %>return Thing.bulkCreate([{<% } %>
           name: 'Development Tools',
           info: 'Integration with popular tools such as Webpack, Gulp, Babel, TypeScript, Karma, '

--- a/templates/app/server/config/seed(models).js
+++ b/templates/app/server/config/seed(models).js
@@ -17,8 +17,8 @@ export default function seedDatabaseIfNeeded() {
     <% if (filters.mongooseModels) { %>Thing.find({}).remove()<% }
        if (filters.sequelizeModels) { %>return Thing.destroy({ where: {} })<% } %>
       .then(() => {
-        <% if (filters.mongooseModels) { %>return Thing.create({<% }
-           if (filters.sequelizeModels) { %>return Thing.bulkCreate([{<% } %>
+        <% if (filters.mongooseModels) { %>let thing = Thing.create({<% }
+           if (filters.sequelizeModels) { %>let thing = Thing.bulkCreate([{<% } %>
           name: 'Development Tools',
           info: 'Integration with popular tools such as Webpack, Gulp, Babel, TypeScript, Karma, '
                 + 'Mocha, ESLint, Node Inspector, Livereload, Protractor, Pug, '
@@ -47,6 +47,7 @@ export default function seedDatabaseIfNeeded() {
                 + 'and openshift subgenerators'
         <% if (filters.mongooseModels) { %>});<% }
          if (filters.sequelizeModels) { %>}]);<% } %>
+        return thing;
     })
     .then(() => console.log('finished populating things'))
     .catch(err => console.log('error populating things', err));

--- a/templates/endpoint/basename.controller.js
+++ b/templates/endpoint/basename.controller.js
@@ -27,6 +27,7 @@ function respondWithResult(res, statusCode) {
 function patchUpdates(patches) {
   return function(entity) {
     try {
+      // eslint-disable-next-line prefer-reflect
       jsonpatch.apply(entity, patches, /*validate*/ true);
     } catch(err) {
       return Promise.reject(err);
@@ -98,7 +99,7 @@ export function create(req, res) {
 // Upserts the given <%= classedName %> in the DB at the specified ID
 export function upsert(req, res) {
   if(req.body._id) {
-    delete req.body._id;
+    Reflect.deleteProperty(req.body, '_id');
   }
   <%_ if(filters.mongooseModels) { -%>
   return <%= classedName %>.findOneAndUpdate({_id: req.params.id}, req.body, {new: true, upsert: true, setDefaultsOnInsert: true, runValidators: true}).exec()<% } %>
@@ -115,7 +116,7 @@ export function upsert(req, res) {
 // Updates an existing <%= classedName %> in the DB
 export function patch(req, res) {
   if(req.body._id) {
-    delete req.body._id;
+    Reflect.deleteProperty(req.body, '_id');
   }
   <% if(filters.mongooseModels) { %>return <%= classedName %>.findById(req.params.id).exec()<% }
      if(filters.sequelizeModels) { %>return <%= classedName %>.find({


### PR DESCRIPTION
- [x] I have read the [Contributing Documents](https://github.com/DaftMonk/generator-angular-fullstack/blob/master/contributing.md)
- [x] My commit(s) follow the [AngularJS commit message guidelines](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/)
- [x] The generator's tests pass (`generator-angular-fullstack$ npm test`)

This PR fixes all warnings and linter errors plus deprecated warnings with the default configuration when installing via yo.

Before:
```bash
~/d/test $ gulp serve                                                                                                                          13:51:15
[13:53:48] Requiring external module babel-register
[13:53:50] Using gulpfile ~/dev/test/gulpfile.babel.js
[13:53:50] Starting 'serve'...
[13:53:50] Starting 'clean:tmp'...
[13:53:50] Starting 'lint:scripts'...
[13:53:50] Starting 'lint:scripts:client'...
[13:53:50] Starting 'lint:scripts:server'...
[13:53:50] Starting 'inject'...
[13:53:50] Starting 'inject:scss'...
[13:53:50] Starting 'copy:fonts:dev'...
[13:53:50] Starting 'env:all'...
[13:53:50] Finished 'env:all' after 8.36 ms
[13:53:50] Finished 'clean:tmp' after 52 ms
[13:53:51] gulp-inject 4 files into app.scss.
[13:53:51] Finished 'inject:scss' after 634 ms
[13:53:51] Finished 'inject' after 635 ms
[13:53:53] 
/Users/ben/dev/test/server/index.js
  4:11  warning  Unexpected use of process.env  no-process-env
  4:34  warning  Unexpected use of process.env  no-process-env

/Users/ben/dev/test/server/config/express.js
  67:25  warning  Unexpected use of process.env  no-process-env

/Users/ben/dev/test/server/api/thing/thing.controller.js
   29:7  warning  Avoid using Function.prototype.apply, instead use Reflect.apply     prefer-reflect
   91:5  warning  Avoid using the delete keyword, instead use Reflect.deleteProperty  prefer-reflect
  102:5  warning  Avoid using the delete keyword, instead use Reflect.deleteProperty  prefer-reflect

/Users/ben/dev/test/server/api/user/user.model.js
  163:15  warning  Use the rest parameters instead of 'arguments'  prefer-rest-params
  164:18  warning  Use the rest parameters instead of 'arguments'  prefer-rest-params
  166:22  warning  Use the rest parameters instead of 'arguments'  prefer-rest-params
  167:18  warning  Use the rest parameters instead of 'arguments'  prefer-rest-params
  207:14  warning  Unexpected sync method: 'pbkdf2Sync'            no-sync

✖ 11 problems (0 errors, 11 warnings)

[13:53:53] Finished 'lint:scripts:server' after 2.48 s
[13:53:53] Finished 'copy:fonts:dev' after 2.48 s
[13:53:53] 
/Users/ben/dev/test/client/components/auth/auth.service.js
  118:19  error    '_' is not defined                                               no-undef
  148:20  error    '_' is not defined                                               no-undef
  161:16  error    '_' is not defined                                               no-undef
  174:29  error    '_' is not defined                                               no-undef
  188:22  error    '_' is not defined                                               no-undef
  199:30  warning  Avoid using Function.prototype.apply, instead use Reflect.apply  prefer-reflect
  199:57  warning  Use the rest parameters instead of 'arguments'                   prefer-rest-params
  208:14  warning  Unexpected sync method: 'hasRoleSync'                            no-sync

/Users/ben/dev/test/client/components/modal/modal.service.js
  42:22  warning  Avoid using Function.prototype.call, instead use Reflect.apply   prefer-reflect
  42:49  warning  Use the rest parameters instead of 'arguments'                   prefer-rest-params
  68:13  warning  Avoid using Function.prototype.apply, instead use Reflect.apply  prefer-reflect

✖ 11 problems (5 errors, 6 warnings)

[13:53:53] Finished 'lint:scripts:client' after 2.61 s
[13:53:53] Finished 'lint:scripts' after 2.61 s
[13:53:53] Starting 'start:server'...
[13:53:53] Finished 'start:server' after 31 ms
[13:53:53] Starting 'start:client'...
[nodemon] 1.11.0
[nodemon] to restart at any time, enter `rs`
[nodemon] watching: /Users/ben/dev/test/server/**/*
[nodemon] starting `node server`
Express server listening on 9000, in development mode
(node:30810) Warning: a promise was created in a handler at Users/ben/dev/test/server/config/seed.js:15:15 but was not returned from it, see http://goo.gl/rRqMUw
    at new Promise (/Users/ben/dev/test/node_modules/bluebird/js/release/promise.js:79:10)
finished populating things
[13:53:55] Finished 'start:client' after 2.65 s
[13:53:55] Starting 'watch'...
Error: ENOENT: no such file or directory, stat '/Users/ben/dev/test/client/index.html'
    at Error (native)
(node:30810) DeprecationWarning: Implicit async custom validators (custom validators that take 2 arguments) are deprecated in mongoose >= 4.9.0. See http://mongoosejs.com/docs/validation.html#async-custom-validators for more info.
[13:53:55] Finished 'watch' after 19 ms
[13:53:55] Finished 'serve' after 5.32 s
[BS] Proxying: http://localhost:9000
[BS] Access URLs:
 --------------------------------------
       Local: http://localhost:3000
    External: http://172.16.30.161:3000
 --------------------------------------
          UI: http://localhost:3002
 UI External: http://172.16.30.161:3002
 --------------------------------------
GET / 404 77.588 ms - 256
Error: ENOENT: no such file or directory, stat '/Users/ben/dev/test/client/index.html'
    at Error (native)
webpack: wait until bundle finished: /
webpack: wait until bundle finished: /api/things
GET / 404 80.174 ms - 256
(node:30810) DeprecationWarning: crypto.pbkdf2 without specifying a digest is deprecated. Please specify a digest
finished populating users
webpack done hook
Hash: d93be40989397afa7944
Version: webpack 1.14.0
Time: 9031ms
                  Asset     Size  Chunks             Chunk Names
          app.bundle.js   432 kB       0  [emitted]  app
    polyfills.bundle.js   206 kB       1  [emitted]  polyfills
       vendor.bundle.js  2.56 MB       2  [emitted]  vendor
      app.bundle.js.map   537 kB       0  [emitted]  app
polyfills.bundle.js.map   267 kB       1  [emitted]  polyfills
   vendor.bundle.js.map  2.98 MB       2  [emitted]  vendor
   ../client/index.html  1.39 kB          [emitted]  
Child html-webpack-plugin for "../client/index.html":
                   Asset     Size  Chunks       Chunk Names
    ../client/index.html  2.69 kB       0       
webpack: Compiled successfully.
webpack: Compiling...
webpack: wait until bundle finished: /vendor.bundle.js
webpack: wait until bundle finished: /polyfills.bundle.js
webpack: wait until bundle finished: /app.bundle.js
GET /api/things 200 37.459 ms - -
webpack done hook
Hash: d93be40989397afa7944
Version: webpack 1.14.0
Time: 141ms
                  Asset     Size  Chunks       Chunk Names
          app.bundle.js   432 kB       0       app
    polyfills.bundle.js   206 kB       1       polyfills
       vendor.bundle.js  2.56 MB       2       vendor
      app.bundle.js.map   537 kB       0       app
polyfills.bundle.js.map   267 kB       1       polyfills
   vendor.bundle.js.map  2.98 MB       2       vendor
Child html-webpack-plugin for "../client/index.html":
                   Asset     Size  Chunks       Chunk Names
    ../client/index.html  2.69 kB       0       
webpack: Compiled successfully.
GET /api/things 304 8.077 ms - -
SocketIO / [127.0.0.1:54113] CONNECTED
GET /api/things 200 27.163 ms - -
```

After:
```bash
~/d/test $ gulp serve                                                                                                                          13:47:13
[13:47:19] Requiring external module babel-register
[13:47:21] Using gulpfile ~/dev/test/gulpfile.babel.js
[13:47:21] Starting 'serve'...
[13:47:21] Starting 'clean:tmp'...
[13:47:21] Starting 'lint:scripts'...
[13:47:21] Starting 'lint:scripts:client'...
[13:47:21] Starting 'lint:scripts:server'...
[13:47:21] Starting 'inject'...
[13:47:21] Starting 'inject:scss'...
[13:47:21] Starting 'copy:fonts:dev'...
[13:47:21] Starting 'env:all'...
[13:47:21] Finished 'env:all' after 4.72 ms
[13:47:21] Finished 'clean:tmp' after 50 ms
[13:47:21] gulp-inject 4 files into app.scss.
[13:47:21] Finished 'inject:scss' after 660 ms
[13:47:21] Finished 'inject' after 661 ms
[13:47:23] Finished 'lint:scripts:server' after 2.45 s
[13:47:23] Finished 'copy:fonts:dev' after 2.44 s
[13:47:23] Finished 'lint:scripts:client' after 2.61 s
[13:47:23] Finished 'lint:scripts' after 2.61 s
[13:47:23] Starting 'start:server'...
[13:47:23] Finished 'start:server' after 13 ms
[13:47:23] Starting 'start:client'...
[nodemon] 1.11.0
[nodemon] to restart at any time, enter `rs`
[nodemon] watching: /Users/ben/dev/test/server/**/*
[nodemon] starting `node server`
Express server listening on 9000, in development mode
[13:47:25] Finished 'start:client' after 2.11 s
[13:47:25] Starting 'watch'...
[13:47:25] Finished 'watch' after 21 ms
[13:47:25] Finished 'serve' after 4.76 s
[BS] Proxying: http://localhost:9000
[BS] Access URLs:
 --------------------------------------
       Local: http://localhost:3000
    External: http://172.16.30.161:3000
 --------------------------------------
          UI: http://localhost:3002
 UI External: http://172.16.30.161:3002
 --------------------------------------
webpack: wait until bundle finished: /
webpack: wait until bundle finished: /api/things
finished populating things
finished populating users
webpack done hook
Hash: 81e3d5d0b4dde6e61b79
Version: webpack 1.14.0
Time: 9143ms
                  Asset     Size  Chunks             Chunk Names
          app.bundle.js   435 kB       0  [emitted]  app
    polyfills.bundle.js   206 kB       1  [emitted]  polyfills
       vendor.bundle.js  2.56 MB       2  [emitted]  vendor
      app.bundle.js.map   540 kB       0  [emitted]  app
polyfills.bundle.js.map   267 kB       1  [emitted]  polyfills
   vendor.bundle.js.map  2.98 MB       2  [emitted]  vendor
   ../client/index.html  1.39 kB          [emitted]  
Child html-webpack-plugin for "../client/index.html":
                   Asset     Size  Chunks       Chunk Names
    ../client/index.html  2.69 kB       0       
webpack: Compiled successfully.
webpack: Compiling...
webpack: wait until bundle finished: /vendor.bundle.js
webpack: wait until bundle finished: /polyfills.bundle.js
webpack: wait until bundle finished: /app.bundle.js
GET /api/things 200 38.965 ms - -
webpack done hook
Hash: 81e3d5d0b4dde6e61b79
Version: webpack 1.14.0
Time: 137ms
                  Asset     Size  Chunks       Chunk Names
          app.bundle.js   435 kB       0       app
    polyfills.bundle.js   206 kB       1       polyfills
       vendor.bundle.js  2.56 MB       2       vendor
      app.bundle.js.map   540 kB       0       app
polyfills.bundle.js.map   267 kB       1       polyfills
   vendor.bundle.js.map  2.98 MB       2       vendor
Child html-webpack-plugin for "../client/index.html":
                   Asset     Size  Chunks       Chunk Names
    ../client/index.html  2.69 kB       0       
webpack: Compiled successfully.
GET /api/things 304 7.036 ms - -
SocketIO / [127.0.0.1:53908] CONNECTED
GET /api/things 200 24.486 ms - -
```