### PR TITLE
Adds Support for Yarn Install If Supported

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -148,7 +148,16 @@ gulp.task('installFixtures', function() {
     }, 1 * 1000);
     shell.cd('test/fixtures');
 
-    execAsync('npm install --quiet', {cwd: '../fixtures'}).then(() => {
+    let installCommand;
+    if(process.platform === 'win32') {
+        installCommand = 'yarn --version >nul 2>&1 && ( yarn install ) || ( npm install --quiet )';
+    } else {
+        installCommand = 'type yarn &> /dev/null | yarn install || npm install --quiet';
+    }
+
+    execAsync(installCommand, {
+        cwd: '../fixtures'
+    }).then(() => {
         process.stdout.write('\n');
         if(!process.env.SAUCE_USERNAME) {
             gutil.log('running npm run-script update-webdriver');

--- a/src/generators/app/index.js
+++ b/src/generators/app/index.js
@@ -606,7 +606,15 @@ export class Generator extends Base {
 
   install() {
     if(!this.options['skip-install']) {
-      this.spawnCommand('npm', ['install']);
+      let yarnCheckCommand;
+      if (process.platform === 'win32') {
+        yarnCheckCommand = 'yarn --version >nul 2>&1';
+      } else {
+        yarnCheckCommand = 'type yarn &> /dev/null';
+      }
+      exec(yarnCheckCommand, (error, stdout, stderr) => {
+        return this.spawnCommand((!error) ? 'yarn' : 'npm', ['install']);
+      });
     }
   }
 


### PR DESCRIPTION
checks if yarn is available and runs yarn install on setup. falls back to npm if yarn is not
installed.

- [x] I have read the [Contributing Documents](https://github.com/DaftMonk/generator-angular-fullstack/blob/master/contributing.md)
- [x] My commit(s) follow the [AngularJS commit message guidelines](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/)
- [x] The generator's tests pass (`generator-angular-fullstack$ npm test`)
