### PR TITLE
fix(tsconfig): fix module resolution for typescript

### DIFF
--- a/templates/app/tsconfig(ts).json
+++ b/templates/app/tsconfig(ts).json
@@ -11,6 +11,10 @@
     "target": "ES5",
     "skipLibCheck": true
   },
+  "moduleResolution": "node",
+  "typeRoots": [
+    "node_modules/@types"
+  ],
   "exclude": [
     "node_modules"
   ],

--- a/templates/app/tsconfig.client.test(ts).json
+++ b/templates/app/tsconfig.client.test(ts).json
@@ -1,12 +1,16 @@
 {
-    "compilerOptions": {
-        "sourceMap": true,
-        "rootDir": "./client",
-        "module": "commonjs",
-        "outDir": ".tmp/test"
-    },
-    "filesGlob": [
-        "client/{app,components}/**/*.{spec,mock}.ts",
-        "client/test_typings/**/*.d.ts"
-    ]
+  "compilerOptions": {
+    "sourceMap": true,
+    "rootDir": "./client",
+    "module": "commonjs",
+    "outDir": ".tmp/test"
+  },
+  "moduleResolution": "node",
+  "typeRoots": [
+    "node_modules/@types"
+  ],
+  "filesGlob": [
+    "client/{app,components}/**/*.{spec,mock}.ts",
+    "client/test_typings/**/*.d.ts"
+  ]
 }


### PR DESCRIPTION
- [x] I have read the [Contributing Documents](https://github.com/DaftMonk/generator-angular-fullstack/blob/master/contributing.md)
- [x] My commit(s) follow the [AngularJS commit message guidelines](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/)
- [ ] The generator's tests pass (`generator-angular-fullstack$ npm test`)

fix module resolution for typescript when module are located in folder node_modules.
