### PR TITLE
fix(tsconfig) Move setting moduleResolution inside compilerOptions section

### DIFF
--- a/templates/app/tsconfig(ts).json
+++ b/templates/app/tsconfig(ts).json
@@ -8,10 +8,10 @@
     "module": "es6",
     "outDir": ".tmp",
     "removeComments": false,
-    "target": "ES5",
-    "skipLibCheck": true
+    "target": "es5",
+    "skipLibCheck": true,
+    "moduleResolution": "node"
   },
-  "moduleResolution": "node",
   "typeRoots": [
     "node_modules/@types"
   ],


### PR DESCRIPTION
- [x ] I have read the [Contributing Documents](https://github.com/DaftMonk/generator-angular-fullstack/blob/master/contributing.md)
- [x ] My commit(s) follow the [AngularJS commit message guidelines](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/)
- [ ] The generator's tests pass (`generator-angular-fullstack$ npm test`)

Move setting moduleResolution inside compilerOptions section to allow module resolution to work as expected.
