### PR TITLE
fix(ts): exclude typescript spec files generating errors on transpilling

### DIFF
--- a/templates/app/tsconfig(ts).json
+++ b/templates/app/tsconfig(ts).json
@@ -20,7 +20,8 @@
     "./node_modules/@types/"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "client/**/*.spec.ts"
   ],
   "filesGlob": [
     "client/{app,components}/**/!(*.spec).ts"


### PR DESCRIPTION
- [ x] I have read the [Contributing Documents](https://github.com/DaftMonk/generator-angular-fullstack/blob/master/contributing.md)
- [ x] My commit(s) follow the [AngularJS commit message guidelines](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/)
- [ ] The generator's tests pass (`generator-angular-fullstack$ npm test`)
