### PR TITLE
fix(app): fix webpack.make.js typos

### DIFF
--- a/templates/app/webpack.make.js
+++ b/templates/app/webpack.make.js
@@ -268,7 +268,7 @@ module.exports = function makeWebpackConfig(options) {
                 <%_ if(!filters.flow) { -%>
                 comments: false<% } %>
             },<% } %>
-        }),
+        })
     ];
 
     if(!TEST) {
@@ -320,7 +320,7 @@ module.exports = function makeWebpackConfig(options) {
                 compress: {
                     warnings: false
                 }
-            }),
+            })
         );
     }
 


### PR DESCRIPTION
Fixed two comma typos in webpack.make.js which caused problems when calling `npm run start:client` on some node/npm versions

- [x] I have read the [Contributing Documents](https://github.com/DaftMonk/generator-angular-fullstack/blob/master/contributing.md)
- [x] My commit(s) follow the [AngularJS commit message guidelines](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/)
- [x] The generator's tests pass (`generator-angular-fullstack$ npm test`)
