### PR TITLE
fix(app): wrong engines in package.json #2696

### DIFF
--- a/templates/app/_package.json
+++ b/templates/app/_package.json
@@ -210,8 +210,8 @@
     "tslint": "^5.7.0"<% } %>
   },
   "engines": {
-    "node": "^6.2.2",
-    "npm": "^3.9.5"
+    "node": ">=6.x.x",
+    "npm": ">=3.9.5"
   },
   "scripts": {
     "postinstall": "gulp copy:fonts:dev",


### PR DESCRIPTION
Changed required node version to >= 6.x.x for now (like discussed in #2696), so that the installation is not limited to node 6.
Also npm >= 3.9.5, since current version is 5.7.1.

I am using rc1 with node 8.10.0 + npm 5.7.1 and haven't encountered any issues so far.

Closes #2696

- [x] I have read the [Contributing Documents](https://github.com/DaftMonk/generator-angular-fullstack/blob/master/contributing.md)
- [x] My commit(s) follow the [AngularJS commit message guidelines](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/)
- [x] The generator's tests pass (`generator-angular-fullstack$ npm test`)
