### PR TITLE
Update _package.json

### DIFF
--- a/templates/app/_package.json
+++ b/templates/app/_package.json
@@ -30,7 +30,7 @@
     "babel-runtime": "^6.18.0",<% if(filters.pug) { %>
     "pug": "2.0.0-beta6",<% } %><% if(filters.html) { %>
     "ejs": "^2.5.3",<% } %><% if(filters.mongoose) { %>
-    "mongoose": "^4.1.2",
+    "mongoose": "4.1.2",
     "bluebird": "^3.3.3",
     "connect-mongo": "^2.0.1",<% } %><% if(filters.sequelize) { %>
     "sequelize": "^3.23.6",


### PR DESCRIPTION
Change "mongoose": "4.1.2" to "mongoose": "^4.1.2"
Cause: 
DeprecationWarning: `open()` is deprecated in mongoose >= 4.11.0, use `openUri()` instead, or set the `useMongoClient` option if using `connect()` or `createConnection()`.

- [x] I have read the [Contributing Documents](https://github.com/DaftMonk/generator-angular-fullstack/blob/master/contributing.md)
- [x] My commit(s) follow the [AngularJS commit message guidelines](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/)
- [x] The generator's tests pass (`generator-angular-fullstack$ npm test`)
