### PR TITLE
Issue #2732: SequelizeStore needs to be created object containing db reference

### DIFF
--- a/templates/app/server/config/express.js
+++ b/templates/app/server/config/express.js
@@ -63,7 +63,9 @@ export default function(app) {
             mongooseConnection: mongoose.connection,
             db: '<%= lodash.slugify(lodash.humanize(appname)) %>'
         })<% } else if(filters.sequelize) { %>,
-        store: new Store(sqldb.sequelize)<% } %>
+        store: new Store({
+            db: sqldb.sequelize
+        })<% } %>
     }));
 
     /**


### PR DESCRIPTION
- [x] I have read the [Contributing Documents](https://github.com/DaftMonk/generator-angular-fullstack/blob/master/contributing.md)
- [x] My commit(s) follow the [AngularJS commit message guidelines](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/)
- [] The generator's tests pass (`generator-angular-fullstack$ npm test`) 
- But they didn't run beforehand... however npm run start:server now works.

Hi! This pull will fix Issue #2732 and make the session store work for those using sequelize.
