### PR TITLE
Generation step added to readme.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,11 @@ Install `yo`, `gulp-cli`, and `generator-angular-fullstack`:
 ```
 npm install -g yo gulp-cli generator-angular-fullstack
 ```
+Generate app
+```
+yo angular-fullstack your-new-app-name
+```
+
 __Please note__: If you run into trouble compiling native add-ons during the installation, follow [`node-gyp`](https://github.com/nodejs/node-gyp)'s short guide on [required compilation tools](https://github.com/nodejs/node-gyp#installation).
 
 Then, to run your app (make sure the MongoDB daemon is running if you selected Mongo), run the following to start your server:


### PR DESCRIPTION
- [ x] I have read the [Contributing Documents](https://github.com/DaftMonk/generator-angular-fullstack/blob/master/contributing.md)
- [ x] My commit(s) follow the [AngularJS commit message guidelines](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/)
- [ x] The generator's tests pass (`generator-angular-fullstack$ npm test`)

Probably generation step is missing in readme