### PR TITLE
chore(server): migrate from new Buffer to Buffer.from

### DIFF
--- a/src/generators/app/index.js
+++ b/src/generators/app/index.js
@@ -471,7 +471,7 @@ export class Generator extends Base {
               .toSource();
           }
 
-          file.contents = new Buffer(contents);
+          file.contents = Buffer.from(contents);
         });
 
         let clientJsFilter = filter(['client/**/*.js'], {restore: true});
@@ -508,7 +508,7 @@ export class Generator extends Base {
             tap(function(file, t) {
               var contents = file.contents.toString();
               contents = replacer(contents);
-              file.contents = new Buffer(contents);
+              file.contents = Buffer.from(contents);
             }),
             tsFilter.restore
           ]);
@@ -546,7 +546,7 @@ export class Generator extends Base {
             }),
             tap(file => {
               const contents = pugReplacer(file.contents.toString());
-              file.contents = new Buffer(contents);
+              file.contents = Buffer.from(contents);
             }),
             pugFilter.restore
           ]);

--- a/templates/app/server/api/user(auth)/user.model(mongooseModels).js
+++ b/templates/app/server/api/user(auth)/user.model(mongooseModels).js
@@ -241,7 +241,7 @@ UserSchema.methods = {
 
         var defaultIterations = 10000;
         var defaultKeyLength = 64;
-        var salt = new Buffer(this.salt, 'base64');
+        var salt = Buffer.from(this.salt, 'base64');
 
         if(!callback) {
             return crypto.pbkdf2Sync(password, salt, defaultIterations, defaultKeyLength, 'sha256')

--- a/templates/app/server/api/user(auth)/user.model(sequelizeModels).js
+++ b/templates/app/server/api/user(auth)/user.model(sequelizeModels).js
@@ -163,7 +163,7 @@ export default function(sequelize, DataTypes) {
 
         var defaultIterations = 10000;
         var defaultKeyLength = 64;
-        var salt = new Buffer(this.salt, 'base64');
+        var salt = Buffer.from(this.salt, 'base64');
 
         if(!callback) {
             return crypto.pbkdf2Sync(password, salt, defaultIterations, defaultKeyLength, 'sha256')


### PR DESCRIPTION
new Buffer(...) has been deprecated since node v6.0.0 and Buffer.from methods should used instead

Fixes #2753

(This pull request will conflict with pull request #2750 -  but the conflict is very easy to resolve.) 

- [x] I have read the [Contributing Documents](https://github.com/DaftMonk/generator-angular-fullstack/blob/master/contributing.md)
- [x] My commit(s) follow the [AngularJS commit message guidelines](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/)
- [x] The generator's tests pass (`generator-angular-fullstack$ npm test`)
