### PR TITLE
fix(client): remove polyfills from Webpack entry

### DIFF
--- a/templates/app/webpack.make.js
+++ b/templates/app/webpack.make.js
@@ -39,7 +39,6 @@ module.exports = function makeWebpackConfig(options) {
     if(!TEST) {
         config.entry = {
             app: './client/app/app.<%= scriptExt %>',
-            polyfills: './client/app/polyfills.<%= scriptExt %>',
             vendor: [
                 'lodash'
             ]


### PR DESCRIPTION
Since the file is also imported, this caused Zone.js to be loaded twice, which was breaking the front end

fixes #2764