### PR TITLE
fix(gulpfile): removed ref to .htaccess

### DIFF
--- a/templates/app/gulpfile.babel.js
+++ b/templates/app/gulpfile.babel.js
@@ -503,8 +503,7 @@ gulp.task('revReplaceWebpack', function() {
 gulp.task('copy:extras', () => {
     return gulp.src([
         `${clientPath}/favicon.ico`,
-        `${clientPath}/robots.txt`,
-        `${clientPath}/.htaccess`
+        `${clientPath}/robots.txt`
     ], { dot: true })
         .pipe(gulp.dest(`${paths.dist}/${clientPath}`));
 });


### PR DESCRIPTION
/client/.htaccess is no longer part of the project

- [x] I have read the [Contributing Documents](https://github.com/DaftMonk/generator-angular-fullstack/blob/master/contributing.md)
- [x] My commit(s) follow the [AngularJS commit message guidelines](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/)
- [x] The generator's tests pass (`generator-angular-fullstack$ npm test`)
